### PR TITLE
Support for ICU 61 and later

### DIFF
--- a/lib/fs/fs.cpp
+++ b/lib/fs/fs.cpp
@@ -10,7 +10,7 @@ namespace fs = std::experimental::filesystem;
 
 #define FS_STRING    "FS"
 
-typedef std::vector<UnicodeString> UnicodeStrings;
+typedef std::vector<icu::UnicodeString> UnicodeStrings;
 
 // convenience functions
 VMObjectPtr path_to_object(const fs::path& p) {
@@ -1429,8 +1429,8 @@ public:
 
 // FS.status_known - checks whether file status is known XXX
 
-extern "C" std::vector<UnicodeString> egel_imports() {
-    return std::vector<UnicodeString>();
+extern "C" std::vector<icu::UnicodeString> egel_imports() {
+    return std::vector<icu::UnicodeString>();
 }
 
 extern "C" std::vector<VMObjectPtr> egel_exports(VM* vm) {

--- a/lib/io/channel.hpp
+++ b/lib/io/channel.hpp
@@ -18,14 +18,14 @@ public:
         _message("")  {
     }
 
-    Unsupported(const UnicodeString &m) :
+    Unsupported(const icu::UnicodeString &m) :
         _message(m)  {
     }
 
     ~Unsupported() {
     }
 
-    UnicodeString message() const {
+    icu::UnicodeString message() const {
         return _message;
     }
 
@@ -35,7 +35,7 @@ public:
     }
 
 private:
-    UnicodeString   _message;
+    icu::UnicodeString   _message;
 };
 
 typedef enum {
@@ -68,7 +68,7 @@ public:
         throw Unsupported();
     }
 
-    virtual void write(const UnicodeString& n) {
+    virtual void write(const icu::UnicodeString& n) {
         throw Unsupported();
     }
 
@@ -84,7 +84,7 @@ public:
         throw Unsupported();
     }
 
-    virtual UnicodeString read_line() {
+    virtual icu::UnicodeString read_line() {
         throw Unsupported();
     }
 
@@ -129,10 +129,10 @@ public:
         return c;
     }
 
-    virtual UnicodeString read_line() override {
+    virtual icu::UnicodeString read_line() override {
         std::string line;
         std::getline(_channel, line);
-        UnicodeString str(line.c_str(), -1, US_INV);
+        icu::UnicodeString str(line.c_str(), -1, US_INV);
         return str;
     }
 
@@ -163,10 +163,10 @@ public:
     }
 
     virtual void write(vm_char_t c) override {
-        _channel << (UnicodeString() + c);
+        _channel << (icu::UnicodeString() + c);
     }
 
-    virtual void write(const UnicodeString& s) override {
+    virtual void write(const icu::UnicodeString& s) override {
         _channel << s;
     }
 
@@ -180,13 +180,13 @@ protected:
 
 class ChannelFile: public Channel {
 public:
-    ChannelFile(const UnicodeString& fn): Channel(CHANNEL_FILE), _fn(fn) {
+    ChannelFile(const icu::UnicodeString& fn): Channel(CHANNEL_FILE), _fn(fn) {
         char* bf = unicode_to_char(fn);
         _channel = std::fstream(bf);
         delete bf;
     }
 
-    static ChannelPtr create(const UnicodeString& fn) {
+    static ChannelPtr create(const icu::UnicodeString& fn) {
         return ChannelPtr(new ChannelFile(fn));
     }
 
@@ -208,10 +208,10 @@ public:
         return c;
     }
 
-    virtual UnicodeString read_line() override {
+    virtual icu::UnicodeString read_line() override {
         std::string line;
         std::getline(_channel, line);
-        UnicodeString str(line.c_str(), -1, US_INV);
+        icu::UnicodeString str(line.c_str(), -1, US_INV);
         return str;
     }
 
@@ -225,10 +225,10 @@ public:
     }
 
     virtual void write(vm_char_t c) override {
-        _channel << (UnicodeString() + c);
+        _channel << (icu::UnicodeString() + c);
     }
 
-    virtual void write(const UnicodeString& s) override {
+    virtual void write(const icu::UnicodeString& s) override {
         _channel << s;
     }
 
@@ -244,7 +244,7 @@ public:
         return _channel.eof();
     }
 private:
-    static char* unicode_to_char(const UnicodeString& str) {
+    static char* unicode_to_char(const icu::UnicodeString& str) {
         unsigned int buffer_size = 1024; // XXX: this is always a bad idea.
         char* buffer = new char[buffer_size];
         unsigned int size = str.extract(0, str.length(), buffer, buffer_size, "UTF-8");//XXX: null, UTF-8, or platform specific?
@@ -253,7 +253,7 @@ private:
     }
 
 protected:
-    UnicodeString   _fn;
+    icu::UnicodeString   _fn;
     std::fstream    _channel;
 };
 

--- a/lib/io/io.cpp
+++ b/lib/io/io.cpp
@@ -134,7 +134,7 @@ public:
 
     VMObjectPtr apply(const VMObjectPtrs& args) const override {
 
-        UnicodeString s;
+        icu::UnicodeString s;
         for (auto& arg:args) {
             if (arg->tag() == VM_OBJECT_INTEGER) {
                 s += arg->to_text();
@@ -168,7 +168,7 @@ public:
     VMObjectPtr apply() const override {
         std::string line;
         std::getline(std::cin, line);
-        UnicodeString str(line.c_str());
+        icu::UnicodeString str(line.c_str());
         return create_text(str);
     }
 };
@@ -476,8 +476,8 @@ public:
 // channel. This works only for regular files. On files of other
 // kinds, the result is meaningless.
 
-extern "C" std::vector<UnicodeString> egel_imports() {
-    return std::vector<UnicodeString>();
+extern "C" std::vector<icu::UnicodeString> egel_imports() {
+    return std::vector<icu::UnicodeString>();
 }
 
 extern "C" std::vector<VMObjectPtr> egel_exports(VM* vm) {

--- a/lib/random/random.cpp
+++ b/lib/random/random.cpp
@@ -49,8 +49,8 @@ public:
     }
 };
 
-extern "C" std::vector<UnicodeString> egel_imports() {
-    return std::vector<UnicodeString>();
+extern "C" std::vector<icu::UnicodeString> egel_imports() {
+    return std::vector<icu::UnicodeString>();
 }
 
 extern "C" std::vector<VMObjectPtr> egel_exports(VM* vm) {

--- a/lib/regex/regex.cpp
+++ b/lib/regex/regex.cpp
@@ -9,7 +9,7 @@
 
 #define REGEX_STRING    "Regex"
 
-typedef std::vector<UnicodeString> UnicodeStrings;
+typedef std::vector<icu::UnicodeString> UnicodeStrings;
 
 // convenience function
 VMObjectPtr strings_to_list(VM* vm, UnicodeStrings ss) {
@@ -38,7 +38,7 @@ typedef std::shared_ptr<Regex>  RegexPtr;
 
 class Regex: public Opaque {
 public:
-    Regex(VM* vm, RegexPattern* p)
+    Regex(VM* vm, icu::RegexPattern* p)
         : Opaque(vm, REGEX_STRING, "pattern"), _pattern(p) {
     }
 
@@ -74,15 +74,15 @@ public:
         }
     }
 
-    RegexPattern* pattern() const {
+    icu::RegexPattern* pattern() const {
         return _pattern;
     }
 
-    UnicodeString string() const {
+    icu::UnicodeString string() const {
         return _pattern->pattern();
     }
     
-    RegexMatcher* matcher(const UnicodeString& s) {
+    icu::RegexMatcher* matcher(const icu::UnicodeString& s) {
         UErrorCode  error_code = U_ZERO_ERROR;
         auto m = _pattern->matcher(s, error_code);
         if (U_FAILURE(error_code)) {
@@ -111,7 +111,7 @@ public:
     }
 
 private:
-    RegexPattern* _pattern;
+    icu::RegexPattern* _pattern;
 };
 
 // Regex.compile s0
@@ -124,8 +124,8 @@ public:
             auto s0 = VM_OBJECT_TEXT_VALUE(arg0);
             UParseError parse_error;
             UErrorCode  error_code = U_ZERO_ERROR;
-            UnicodeString pat = s0;
-            RegexPattern* p = icu::RegexPattern::compile(pat, parse_error, error_code);
+            icu::UnicodeString pat = s0;
+            icu::RegexPattern* p = icu::RegexPattern::compile(pat, parse_error, error_code);
             if (U_FAILURE(error_code)) {
                 return nullptr;
             } else {
@@ -194,13 +194,13 @@ public:
                 start = r->start(error_code);
                 end   = r->end(error_code);
                 
-                UnicodeString s;
+                icu::UnicodeString s;
                 s0.extract(pos, start-pos, s);
                 ss.push_back(s);
 
                 pos = end;
             }
-            UnicodeString s;
+            icu::UnicodeString s;
             s0.extract(pos, s0.length()-pos, s);
             ss.push_back(s);
             delete r;
@@ -231,7 +231,7 @@ public:
                 auto start = r->start(error_code);
                 auto end   = r->end(error_code);
                 
-                UnicodeString s;
+                icu::UnicodeString s;
                 s0.extract(start, end-start, s);
                 ss.push_back(s);
             }
@@ -302,8 +302,8 @@ public:
     }
 };
 
-extern "C" std::vector<UnicodeString> egel_imports() {
-    return std::vector<UnicodeString>();
+extern "C" std::vector<icu::UnicodeString> egel_imports() {
+    return std::vector<icu::UnicodeString>();
 }
 
 extern "C" std::vector<VMObjectPtr> egel_exports(VM* vm) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -40,7 +40,7 @@ int compare_asts(const AstPtrs& aa0, const AstPtrs& aa1) {
     }
 }
 
-int compare_text(const UnicodeString& t0, const UnicodeString& t1) {
+int compare_text(const icu::UnicodeString& t0, const icu::UnicodeString& t1) {
     return t0.compare(t1);
 }
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -97,10 +97,10 @@ public:
 
     virtual void render(std::ostream& os, uint_t indent) const = 0;
 
-    virtual UnicodeString to_text() const {
+    virtual icu::UnicodeString to_text() const {
         std::stringstream ss;
         render(ss, Ast::line_length);
-        UnicodeString u(ss.str().c_str());
+        icu::UnicodeString u(ss.str().c_str());
         return u;
     }
 
@@ -132,7 +132,7 @@ typedef std::set<AstPtr, LessAstPtr> AstPtrSet;
 class AstEmpty : public Ast {
 public:
     AstEmpty()
-        : Ast(AST_EMPTY, Position(UnicodeString(""), 0, 0)) {
+        : Ast(AST_EMPTY, Position(icu::UnicodeString(""), 0, 0)) {
     }
 
     AstEmpty(const AstEmpty& e): AstEmpty() {
@@ -158,11 +158,11 @@ typedef std::shared_ptr<AstEmpty> AstEmptyPtr;
 
 class AstAtom : public Ast {
 public:
-    AstAtom(ast_tag_t t, const Position &p,  const UnicodeString &n)
+    AstAtom(ast_tag_t t, const Position &p,  const icu::UnicodeString &n)
         : Ast(t, p), _text(n) {
     }
 
-    UnicodeString text() const {
+    icu::UnicodeString text() const {
         return _text;
     }
 
@@ -175,14 +175,14 @@ public:
     }
 
 private:
-    UnicodeString _text;
+    icu::UnicodeString _text;
 };
 
 // expression literals
 
 class AstExprInteger : public AstAtom {
 public:
-    AstExprInteger(const Position &p,  const UnicodeString &text)
+    AstExprInteger(const Position &p,  const icu::UnicodeString &text)
         : AstAtom(AST_EXPR_INTEGER, p, text) {
     };
 
@@ -206,7 +206,7 @@ typedef std::shared_ptr<AstExprInteger> AstExprIntegerPtr;
 
 class AstExprHexInteger : public AstAtom {
 public:
-    AstExprHexInteger(const Position &p,  const UnicodeString &text)
+    AstExprHexInteger(const Position &p,  const icu::UnicodeString &text)
         : AstAtom(AST_EXPR_HEXINTEGER, p, text)
     {};
 
@@ -230,7 +230,7 @@ typedef std::shared_ptr<AstExprHexInteger> AstExprHexIntegerPtr;
 
 class AstExprFloat : public AstAtom {
 public:
-    AstExprFloat(const Position &p,  const UnicodeString &text)
+    AstExprFloat(const Position &p,  const icu::UnicodeString &text)
         : AstAtom(AST_EXPR_FLOAT, p, text)
     {};
 
@@ -254,7 +254,7 @@ typedef std::shared_ptr<AstExprFloat> AstExprFloatPtr;
 
 class AstExprCharacter : public AstAtom {
 public:
-    AstExprCharacter(const Position &p,  const UnicodeString &text)
+    AstExprCharacter(const Position &p,  const icu::UnicodeString &text)
         : AstAtom(AST_EXPR_CHARACTER, p, text)
     {};
 
@@ -278,7 +278,7 @@ typedef std::shared_ptr<AstExprCharacter> AstExprCharacterPtr;
 
 class AstExprText : public AstAtom {
 public:
-    AstExprText(const Position &p,  const UnicodeString &text)
+    AstExprText(const Position &p,  const icu::UnicodeString &text)
         : AstAtom(AST_EXPR_TEXT, p, text) {
     };
 
@@ -304,7 +304,7 @@ typedef std::shared_ptr<AstExprText> AstExprTextPtr;
 
 class AstExprVariable : public AstAtom {
 public:
-    AstExprVariable(const Position &p,  const UnicodeString &text)
+    AstExprVariable(const Position &p,  const icu::UnicodeString &text)
         : AstAtom(AST_EXPR_VARIABLE, p, text) {
     };
 
@@ -327,7 +327,7 @@ typedef std::shared_ptr<AstExprVariable> AstExprVariablePtr;
 
 class AstExprWildcard : public AstAtom {
 public:
-    AstExprWildcard(const Position &p,  const UnicodeString &text)
+    AstExprWildcard(const Position &p,  const icu::UnicodeString &text)
         : AstAtom(AST_EXPR_WILDCARD, p, text) {
     };
 
@@ -409,18 +409,18 @@ typedef std::shared_ptr<AstExprTag> AstExprTagPtr;
 
 class AstExprCombinator : public Ast {
 public:
-    AstExprCombinator(const Position &p,  const UnicodeStrings& pp, const UnicodeString &c)
+    AstExprCombinator(const Position &p,  const UnicodeStrings& pp, const icu::UnicodeString &c)
         : Ast(AST_EXPR_COMBINATOR, p), _path(pp), _combinator(c) {
     };
 
-    AstExprCombinator(const Position &p,  const UnicodeString& n, const UnicodeString &c)
+    AstExprCombinator(const Position &p,  const icu::UnicodeString& n, const icu::UnicodeString &c)
         : Ast(AST_EXPR_COMBINATOR, p), _combinator(c) {
             UnicodeStrings nn;
             nn.push_back(n);
             _path = nn;
     };
 
-    AstExprCombinator(const Position &p,  const UnicodeString &c)
+    AstExprCombinator(const Position &p,  const icu::UnicodeString &c)
         : Ast(AST_EXPR_COMBINATOR, p), _combinator(c) {
             UnicodeStrings nn;
             _path = nn;
@@ -438,12 +438,12 @@ public:
         return _path;
     }
 
-    UnicodeString combinator() const {
+    icu::UnicodeString combinator() const {
         return _combinator;
     }
 
-    UnicodeString to_text() const override {
-        UnicodeString str = "";
+    icu::UnicodeString to_text() const override {
+        icu::UnicodeString str = "";
         for (auto& p:_path) {
             str += p;
             str += STRING_COLON;
@@ -464,7 +464,7 @@ public:
 
 private:
     UnicodeStrings  _path;
-    UnicodeString   _combinator;
+    icu::UnicodeString   _combinator;
 };
 
 typedef std::shared_ptr<AstExprCombinator> AstExprCombinatorPtr;
@@ -477,11 +477,11 @@ typedef std::shared_ptr<AstExprCombinator> AstExprCombinatorPtr;
 
 class AstExprOperator : public Ast {
 public:
-    AstExprOperator(const Position &p,  const UnicodeStrings& pp, const UnicodeString &c)
+    AstExprOperator(const Position &p,  const UnicodeStrings& pp, const icu::UnicodeString &c)
         : Ast(AST_EXPR_OPERATOR, p), _path(pp), _combinator(c) {
     };
 
-    AstExprOperator(const Position &p,  const UnicodeString& n, const UnicodeString &c)
+    AstExprOperator(const Position &p,  const icu::UnicodeString& n, const icu::UnicodeString &c)
         : Ast(AST_EXPR_OPERATOR, p), _combinator(c) {
             UnicodeStrings nn;
             nn.push_back(n);
@@ -500,12 +500,12 @@ public:
         return _path;
     }
 
-    UnicodeString combinator() const {
+    icu::UnicodeString combinator() const {
         return _combinator;
     }
 
-    UnicodeString text() const {
-        UnicodeString str = "";
+    icu::UnicodeString text() const {
+        icu::UnicodeString str = "";
         for (auto& p:_path) {
             str += p;
             str += STRING_COLON;
@@ -531,7 +531,7 @@ public:
 
 private:
     UnicodeStrings  _path;
-    UnicodeString   _combinator;
+    icu::UnicodeString   _combinator;
 };
 
 typedef std::shared_ptr<AstExprOperator> AstExprOperatorPtr;
@@ -1685,7 +1685,7 @@ typedef std::shared_ptr<AstDeclObject> AstDeclObjectPtr;
 
 class AstDirectImport : public Ast {
 public:
-    AstDirectImport(const Position &p,  const UnicodeString &v)
+    AstDirectImport(const Position &p,  const icu::UnicodeString &v)
         : Ast(AST_DIRECT_IMPORT, p), _import(v) {
     }
 
@@ -1697,7 +1697,7 @@ public:
         return AstPtr(new AstDirectImport(*this));
     }
 
-    UnicodeString import() const {
+    icu::UnicodeString import() const {
         return _import;
     }
 
@@ -1713,7 +1713,7 @@ public:
     }
 
 private:
-    UnicodeString _import;
+    icu::UnicodeString _import;
 };
 
 typedef std::shared_ptr<AstDirectImport> AstDirectImportPtr;

--- a/src/builtin/string.cpp
+++ b/src/builtin/string.cpp
@@ -110,7 +110,7 @@ public:
 };
 
 // String.compare s0 s1
-// Compare the characters bitwise in this UnicodeString to the characters in text. 
+// Compare the characters bitwise in this icu::UnicodeString to the characters in text. 
 class Compare: public Dyadic {
 public:
     DYADIC_PREAMBLE(Compare, "String", "compare");
@@ -331,7 +331,7 @@ public:
 };
 
 // String.append s0 s1
-// Append the characters in srcText to the UnicodeString object. 
+// Append the characters in srcText to the icu::UnicodeString object. 
 class Append: public Dyadic {
 public:
     DYADIC_PREAMBLE(Append, "String", "append");
@@ -353,7 +353,7 @@ public:
 
 
 // String.insert s0 n s1
-// Insert the characters in srcText into the UnicodeString object at offset start. 
+// Insert the characters in srcText into the icu::UnicodeString object at offset start. 
 class Insert: public Triadic {
 public:
     TRIADIC_PREAMBLE(Insert, "String", "insert");
@@ -389,7 +389,7 @@ public:
 };
 
 // String.remove n0 n1 s0
-// Remove the characters in the range [start, limit) from the UnicodeString object. 
+// Remove the characters in the range [start, limit) from the icu::UnicodeString object. 
 class Remove: public Triadic {
 public:
     TRIADIC_PREAMBLE(Remove, "String", "remove");
@@ -407,7 +407,7 @@ public:
 };
 
 // String.retain n0 n1 s0
-// Retain the characters in the range [start, limit) from the UnicodeString object. 
+// Retain the characters in the range [start, limit) from the icu::UnicodeString object. 
 class Retain: public Triadic {
 public:
     TRIADIC_PREAMBLE(Retain, "String", "retain");
@@ -425,7 +425,7 @@ public:
 };
 
 // String.trim s 
-// Trims leading and trailing whitespace from this UnicodeString. 
+// Trims leading and trailing whitespace from this icu::UnicodeString. 
 class Trim: public Monadic {
 public:
     MONADIC_PREAMBLE(Trim, "String", "trim");
@@ -441,7 +441,7 @@ public:
 };
 
 // String.reverse s 
-// Reverse this UnicodeString in place. 
+// Reverse this icu::UnicodeString in place. 
 class Reverse: public Monadic {
 public:
     MONADIC_PREAMBLE(Reverse, "String", "reverse");

--- a/src/builtin/system.cpp
+++ b/src/builtin/system.cpp
@@ -643,7 +643,7 @@ public:
         static symbol_t _cons = 0;
         if (_cons == 0) _cons = machine()->enter_symbol("System", "cons");
 
-        UnicodeString ss;
+        icu::UnicodeString ss;
         auto a = arg0;
 
         while ( (a->tag() == VM_OBJECT_ARRAY) ) {

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -536,15 +536,15 @@ public:
         : VMObjectCombinator(VM_OBJECT_FLAG_COMBINATOR, m, s), _code(c) {
     };
     
-    VMObjectBytecode(VM* m, const Code& c, const UnicodeString& n)
+    VMObjectBytecode(VM* m, const Code& c, const icu::UnicodeString& n)
         : VMObjectCombinator(VM_OBJECT_FLAG_COMBINATOR, m, n), _code(c) {
     };
     
-    VMObjectBytecode(VM* m, const Code& c, const UnicodeString& n0, const UnicodeString& n1)
+    VMObjectBytecode(VM* m, const Code& c, const icu::UnicodeString& n0, const icu::UnicodeString& n1)
         : VMObjectCombinator(VM_OBJECT_FLAG_COMBINATOR, m, n0, n1), _code(c) {
     };
     
-    VMObjectBytecode(VM* m, const Code& c, const UnicodeStrings& nn, const UnicodeString& n)
+    VMObjectBytecode(VM* m, const Code& c, const UnicodeStrings& nn, const icu::UnicodeString& n)
         : VMObjectCombinator(VM_OBJECT_FLAG_COMBINATOR, m, nn, n), _code(c) {
     };
     

--- a/src/desugar.cpp
+++ b/src/desugar.cpp
@@ -18,8 +18,8 @@ public:
         return _tick++;
     }
 
-    AstPtr rewrite_expr_wildcard(const Position& p, const UnicodeString& v) override {
-        UnicodeString w = "WILD";
+    AstPtr rewrite_expr_wildcard(const Position& p, const icu::UnicodeString& v) override {
+        icu::UnicodeString w = "WILD";
         w = w + unicode_convert_uint(tick());
         return AstExprVariable(p, w).clone();
     }

--- a/src/egel.cpp
+++ b/src/egel.cpp
@@ -62,7 +62,7 @@ static option_t options[] = {
 
 #define OPTIONS_SIZE    (sizeof(options)/sizeof(option_t))
 
-typedef std::vector<std::pair<UnicodeString, UnicodeString> > StringPairs;
+typedef std::vector<std::pair<icu::UnicodeString, icu::UnicodeString> > StringPairs;
 
 StringPairs parse_options(int argc, char *argv[]) {
     StringPairs pp;
@@ -76,26 +76,26 @@ StringPairs parse_options(int argc, char *argv[]) {
                 
                 switch (options[i].argument) {
                 case OPTION_NONE:
-                    pp.push_back(std::make_pair(UnicodeString(options[i].shortname), UnicodeString("")));
+                    pp.push_back(std::make_pair(icu::UnicodeString(options[i].shortname), icu::UnicodeString("")));
                     break;
                 case OPTION_FILE:
                     if (a == argc - 1) goto options_error;
-                    pp.push_back(std::make_pair(UnicodeString(options[i].shortname), UnicodeString(argv[a+1])));
+                    pp.push_back(std::make_pair(icu::UnicodeString(options[i].shortname), icu::UnicodeString(argv[a+1])));
                     a++;
                     break;
                 case OPTION_DIR:
                     if (a == argc - 1) goto options_error;
-                    pp.push_back(std::make_pair(UnicodeString(options[i].shortname), UnicodeString(argv[a+1])));
+                    pp.push_back(std::make_pair(icu::UnicodeString(options[i].shortname), icu::UnicodeString(argv[a+1])));
                     a++;
                     break;
                 case OPTION_NUMBER:
                     if (a == argc - 1) goto options_error;
-                    pp.push_back(std::make_pair(UnicodeString(options[i].shortname), UnicodeString(argv[a+1])));
+                    pp.push_back(std::make_pair(icu::UnicodeString(options[i].shortname), icu::UnicodeString(argv[a+1])));
                     a++;
                     break;
                 case OPTION_TEXT:
                     if (a == argc - 1) goto options_error;
-                    pp.push_back(std::make_pair(UnicodeString(options[i].shortname), UnicodeString(argv[a+1])));
+                    pp.push_back(std::make_pair(icu::UnicodeString(options[i].shortname), icu::UnicodeString(argv[a+1])));
                     a++;
                     break;
                 };
@@ -104,7 +104,7 @@ StringPairs parse_options(int argc, char *argv[]) {
         }
 
         if (sz == pp.size()) {
-            pp.push_back(std::make_pair(UnicodeString("--"), UnicodeString(argv[a])));
+            pp.push_back(std::make_pair(icu::UnicodeString("--"), icu::UnicodeString(argv[a])));
         }
     }
     return pp;
@@ -171,7 +171,7 @@ int main(int argc, char *argv[]) {
     OptionsPtr oo = Options().clone();
 
     // always add local directory to the search path
-    oo->add_include_path(UnicodeString("./"));
+    oo->add_include_path(icu::UnicodeString("./"));
 
     // check for include paths
     for (auto& p : pp) {
@@ -183,7 +183,7 @@ int main(int argc, char *argv[]) {
     // add include path from environment
     auto istr = getenv("EGEL_INCLUDE");
     if (istr != nullptr) {
-        oo->add_include_path(UnicodeString(istr, -1, US_INV));
+        oo->add_include_path(icu::UnicodeString(istr, -1, US_INV));
     } else {
         oo->add_include_path(INCLUDE_PATH);
     }
@@ -214,8 +214,8 @@ int main(int argc, char *argv[]) {
     };
 
     // check for unique --/fn
-    UnicodeString fn;
-    std::vector<UnicodeString> aa;
+    icu::UnicodeString fn;
+    std::vector<icu::UnicodeString> aa;
     for (auto& p : pp) {
         if (p.first == ("--")) {
             if (fn == "") {
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]) {
     };
 
     // check for command
-    UnicodeString e;
+    icu::UnicodeString e;
     for (auto& p : pp) {
         if (p.first == ("-e")) {
             e = p.second;
@@ -266,7 +266,7 @@ int main(int argc, char *argv[]) {
 
     // start either interactive or batch mode
     if (e != "") {
-        eval.eval_command(UnicodeString("using System"));
+        eval.eval_command(icu::UnicodeString("using System"));
         eval.eval_command(e);
     } else if ((fn == "") || oo->interactive()) {
         eval.eval_interactive();

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -5,7 +5,7 @@
 #include "bytecode.hpp"
 #include "emit.hpp"
 
-typedef std::map<UnicodeString, reg_t> RegisterMap;
+typedef std::map<icu::UnicodeString, reg_t> RegisterMap;
 typedef std::unique_ptr<Coder>         CoderPtr;
 
 class EmitData: public Visit {
@@ -15,10 +15,10 @@ public:
         visit(a);
     }
 
-    void visit_directive_import(const Position& p, const UnicodeString& i) override {
+    void visit_directive_import(const Position& p, const icu::UnicodeString& i) override {
     }
 
-    void visit_expr_combinator(const Position& p, const UnicodeStrings& nn, const UnicodeString& n) override {
+    void visit_expr_combinator(const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& n) override {
         auto c = VMObjectData(_machine, nn, n).clone();
         _machine->define_data(c);
     }
@@ -137,11 +137,11 @@ public:
         return _arity;
     }
 
-    void add_variable_binding(const UnicodeString& v, const reg_t t) {
+    void add_variable_binding(const icu::UnicodeString& v, const reg_t t) {
         _variables[v] = t;
     }
 
-    reg_t get_variable_binding(const UnicodeString& v) {
+    reg_t get_variable_binding(const icu::UnicodeString& v) {
         return _variables[v];
     }
 
@@ -192,7 +192,7 @@ public:
         }
     }
 
-    void visit_expr_integer(const Position& p, const UnicodeString& v) override {
+    void visit_expr_integer(const Position& p, const icu::UnicodeString& v) override {
         if (v.startsWith("0x")) {
             auto i = VMObjectInteger(convert_to_hexint(v)).clone();
             auto d = get_machine()->enter_data(i);
@@ -204,35 +204,35 @@ public:
         }
     }
 
-    void visit_expr_float(const Position& p, const UnicodeString& v) override {
+    void visit_expr_float(const Position& p, const icu::UnicodeString& v) override {
         auto i = VMObjectFloat(convert_to_float(v)).clone();
         auto d = get_machine()->enter_data(i);
         visit_constant(d);
     }
 
-    void visit_expr_character(const Position& p, const UnicodeString& v) override {
+    void visit_expr_character(const Position& p, const icu::UnicodeString& v) override {
         auto i = VMObjectChar(convert_to_char(v)).clone();
         auto d = get_machine()->enter_data(i);
         visit_constant(d);
     }
 
-    void visit_expr_text(const Position& p, const UnicodeString& v) override {
+    void visit_expr_text(const Position& p, const icu::UnicodeString& v) override {
         auto i = VMObjectText(convert_to_text(v)).clone();
         auto d = get_machine()->enter_data(i);
         visit_constant(d);
     }
 
-    void visit_expr_combinator(const Position& p, const UnicodeStrings& nn, const UnicodeString& n) override {
+    void visit_expr_combinator(const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& n) override {
         auto c = get_machine()->get_data_string(nn, n);
         auto d = get_machine()->enter_data(c);
         visit_constant(d);
     }
 
-    void visit_expr_operator(const Position& p, const UnicodeStrings& nn, const UnicodeString& n) override {
+    void visit_expr_operator(const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& n) override {
         visit_expr_combinator(p, nn, n);
     }
 
-    void visit_expr_variable(const Position& p, const UnicodeString& n) override {
+    void visit_expr_variable(const Position& p, const icu::UnicodeString& n) override {
         switch(get_state()) {
         case EMIT_PATTERN: {
             auto r = get_current_register();
@@ -537,7 +537,7 @@ public:
         PANIC("throw is combinator");
     }
 
-    void visit_directive_import(const Position& p, const UnicodeString& i) override {
+    void visit_directive_import(const Position& p, const icu::UnicodeString& i) override {
     }
 
     void visit_decl_data(const Position& p, const AstPtrs& nn) override {

--- a/src/environment.hpp
+++ b/src/environment.hpp
@@ -5,14 +5,14 @@
 #include <memory>
 #include "error.hpp"
 
-typedef std::map<UnicodeString, UnicodeString> Table;
+typedef std::map<icu::UnicodeString, icu::UnicodeString> Table;
 
 class Scope;
 typedef std::shared_ptr<Scope>  ScopePtr;
 
 class Scope {
 public:
-    void declare(const UnicodeString& k, const UnicodeString& v) {
+    void declare(const icu::UnicodeString& k, const icu::UnicodeString& v) {
         if (_symbols.count(k) > 0) {
             throw ErrorSemantical("redeclaration of " + k);
         } else {
@@ -20,11 +20,11 @@ public:
         }
     }
 
-    void declare_implicit(const UnicodeString& k, const UnicodeString& v) {
+    void declare_implicit(const icu::UnicodeString& k, const icu::UnicodeString& v) {
         _symbols[k] = v;
     }
 
-    UnicodeString get(const UnicodeString& k) const {
+    icu::UnicodeString get(const icu::UnicodeString& k) const {
         if (_symbols.count(k) > 0) return _symbols.at(k);
         return "";
     }
@@ -37,10 +37,10 @@ public:
         }
     }
 
-    UnicodeString to_text() {
+    icu::UnicodeString to_text() {
         std::stringstream ss;
         render(ss, 0);
-        UnicodeString u(ss.str().c_str());
+        icu::UnicodeString u(ss.str().c_str());
         return u;
     }
 protected:
@@ -49,7 +49,7 @@ protected:
 
 class Namespace;
 typedef std::shared_ptr<Namespace>  NamespacePtr;
-typedef std::map<UnicodeString, NamespacePtr> NamespaceMap;
+typedef std::map<icu::UnicodeString, NamespacePtr> NamespaceMap;
 
 class Namespace: public Scope {
 public:
@@ -64,7 +64,7 @@ public:
         return NamespacePtr(new Namespace(*this));
     }
 
-    NamespacePtr create_namespace(const UnicodeString& n) {
+    NamespacePtr create_namespace(const icu::UnicodeString& n) {
         if (_embeds.count(n) > 0) {
             return _embeds.at(n);
         } else {
@@ -74,7 +74,7 @@ public:
         }
     }
 
-    NamespacePtr find_namespace(const UnicodeString& n) const {
+    NamespacePtr find_namespace(const icu::UnicodeString& n) const {
         if (_embeds.count(n) > 0) {
             return _embeds.at(n);
         } else {
@@ -159,7 +159,7 @@ inline NamespacePtr namespace_nil() {
     return std::make_shared<Namespace>();
 }
 
-inline void declare(const NamespacePtr& p, const UnicodeStrings& nn, const UnicodeString& n, const UnicodeString& v) {
+inline void declare(const NamespacePtr& p, const UnicodeStrings& nn, const icu::UnicodeString& n, const icu::UnicodeString& v) {
     auto ptr = p;
     for (auto& n: nn) {
         ptr = ptr->create_namespace(n);
@@ -167,7 +167,7 @@ inline void declare(const NamespacePtr& p, const UnicodeStrings& nn, const Unico
     ptr->declare(n, v);
 }
 
-inline void declare_implicit(const NamespacePtr& p, const UnicodeStrings& nn, const UnicodeString& n, const UnicodeString& v) {
+inline void declare_implicit(const NamespacePtr& p, const UnicodeStrings& nn, const icu::UnicodeString& n, const icu::UnicodeString& v) {
     auto ptr = p;
     for (auto& n: nn) {
         ptr = ptr->create_namespace(n);
@@ -175,7 +175,7 @@ inline void declare_implicit(const NamespacePtr& p, const UnicodeStrings& nn, co
     ptr->declare_implicit(n, v);
 }
 
-inline UnicodeString get(const NamespacePtr& p, const UnicodeStrings& nn, const UnicodeString& n) {
+inline icu::UnicodeString get(const NamespacePtr& p, const UnicodeStrings& nn, const icu::UnicodeString& n) {
     auto ptr = p;
     for (auto& n: nn) {
         ptr = ptr->find_namespace(n);
@@ -209,29 +209,29 @@ inline RangePtr leave_range(const RangePtr& p) {
     return p->embeds();
 }
 
-inline void declare(const RangePtr& p, const UnicodeString& k, const UnicodeString& v) {
+inline void declare(const RangePtr& p, const icu::UnicodeString& k, const icu::UnicodeString& v) {
     p->declare(k, v);
 }
 
-inline UnicodeString get(const RangePtr& r, const UnicodeString& n) {
+inline icu::UnicodeString get(const RangePtr& r, const icu::UnicodeString& n) {
     static UnicodeStrings nn;
     if (r == nullptr) return "";
-    UnicodeString s = r->get(n);
+    icu::UnicodeString s = r->get(n);
     if (s != "") {
         return s;
     } else {
         for (auto& ptr: r->uses()) {
-            UnicodeString s = get(ptr, nn, n);
+            icu::UnicodeString s = get(ptr, nn, n);
             if (s != "") return s;
         }
         return get(r->embeds(), n);
     }
 }
 
-inline UnicodeString get(const RangePtr& r, const UnicodeStrings& nn, const UnicodeString& n) {
+inline icu::UnicodeString get(const RangePtr& r, const UnicodeStrings& nn, const icu::UnicodeString& n) {
     if (r == nullptr) return "";
     for (auto& ptr: r->uses()) {
-        UnicodeString s = get(ptr, nn, n);
+        icu::UnicodeString s = get(ptr, nn, n);
         if (s != "") return s;
     }
     return get(r->embeds(), nn, n);

--- a/src/error.hpp
+++ b/src/error.hpp
@@ -16,7 +16,7 @@ typedef enum {
 
 class Error : public std::exception {
 public:
-    Error(error_tag_t t, const Position &p, const UnicodeString &m) :
+    Error(error_tag_t t, const Position &p, const icu::UnicodeString &m) :
         _tag(t), _position(p), _message(m)  {
             // useful for debugging, uncomment to get stack trace in debug mode
             //Error* e = (Error*) nullptr;
@@ -30,12 +30,12 @@ public:
         return _position;
     }
     
-    UnicodeString message() const {
+    icu::UnicodeString message() const {
         return _message;
     }
 
-    UnicodeString error() const {
-        UnicodeString s = "";
+    icu::UnicodeString error() const {
+        icu::UnicodeString s = "";
         if (position().resource() != "") {
             s += position().to_text() + ":";
         }
@@ -68,42 +68,42 @@ public:
 private:
     error_tag_t     _tag;
     Position        _position;
-    UnicodeString   _message;
+    icu::UnicodeString   _message;
 };
 
 class ErrorIO: public Error {
 public:
-    ErrorIO(const Position& p, const UnicodeString& m)
+    ErrorIO(const Position& p, const icu::UnicodeString& m)
         : Error(ERROR_IO, p, m) { }
 
-    ErrorIO(const UnicodeString& m)
+    ErrorIO(const icu::UnicodeString& m)
         : Error(ERROR_IO, Position(), m) { }
 };
 
 class ErrorLexical: public Error {
 public:
-    ErrorLexical(const Position& p, const UnicodeString& m)
+    ErrorLexical(const Position& p, const icu::UnicodeString& m)
         : Error(ERROR_LEXICAL, p, m) {}
 };
 
 class ErrorSyntactical: public Error {
 public:
-    ErrorSyntactical(const Position& p, const UnicodeString& m)
+    ErrorSyntactical(const Position& p, const icu::UnicodeString& m)
         : Error(ERROR_SYNTACTICAL, p, m) {}
 };
 
 class ErrorIdentification: public Error {
 public:
-    ErrorIdentification(const Position& p, const UnicodeString& m)
+    ErrorIdentification(const Position& p, const icu::UnicodeString& m)
         : Error(ERROR_IDENTIFICATION, p, m) {}
 };
 
 class ErrorSemantical: public Error {
 public:
-    ErrorSemantical(const Position& p, const UnicodeString& m)
+    ErrorSemantical(const Position& p, const icu::UnicodeString& m)
         : Error(ERROR_SEMANTICAL, p, m) {}
 
-    ErrorSemantical(const UnicodeString& m)
+    ErrorSemantical(const icu::UnicodeString& m)
         : Error(ERROR_SEMANTICAL, Position(), m) { }
 };
 

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -120,11 +120,11 @@ public:
         auto c = vm->get_data_string("main");
 
         if (c->flag() != VM_OBJECT_FLAG_STUB) {
-            eval_command(UnicodeString("main"));
+            eval_command(icu::UnicodeString("main"));
         }
     }
 
-    void eval_load(const UnicodeString& lib) {
+    void eval_load(const icu::UnicodeString& lib) {
         auto mm = get_manager();
         Position p("", 0, 0);
         mm->load(p, lib);
@@ -280,7 +280,7 @@ public:
         }
     }
 
-    void eval_line(const UnicodeString& in, const callback_t& main, const callback_t& exc) {
+    void eval_line(const icu::UnicodeString& in, const callback_t& main, const callback_t& exc) {
         auto mm = get_manager();
         auto vm = get_machine();
 
@@ -316,7 +316,7 @@ public:
         }
     }
 
-    void eval_command(const UnicodeString& in) {
+    void eval_command(const icu::UnicodeString& in) {
         eval_line(in, &default_main_callback, &default_exception_callback);
     }
 
@@ -326,7 +326,7 @@ public:
         std::string s;
         std::cout << ">> ";
         while (std::getline(std::cin, s)) {
-            auto in = UnicodeString::fromUTF8(StringPiece(s.c_str()));
+            auto in = icu::UnicodeString::fromUTF8(icu::StringPiece(s.c_str()));
             try {
                 eval_command(in);
             } catch (Error &e) {

--- a/src/lexical.cpp
+++ b/src/lexical.cpp
@@ -232,16 +232,16 @@ static token_text_t token_text_table[] {
 
 #define TOKEN_TEXT_TABLE_SIZE sizeof(token_text_table)/sizeof(token_text_t)
 
-UnicodeString token_text(token_t t) {
+icu::UnicodeString token_text(token_t t) {
     for (uint_t i = 0; i < TOKEN_TEXT_TABLE_SIZE; i++) {
         if (t == token_text_table[i].tag) {
-            return UnicodeString(token_text_table[i].text);
+            return icu::UnicodeString(token_text_table[i].text);
         }
     }
 
     PANIC("Uknkown token.");
     // surpress warnings
-    return UnicodeString();
+    return icu::UnicodeString();
 }
 
 typedef struct {
@@ -338,7 +338,7 @@ TokenReaderPtr tokenize_from_reader(CharReader &reader) {
         // compound tokens
         } else if (is_quote(c)) {
             // FIXME: doesn't handle backslashes correct
-            UnicodeString str = UnicodeString("");
+            icu::UnicodeString str = icu::UnicodeString("");
             str += c;
             reader.skip();
             if (reader.end() || is_eol(reader.look())) goto handle_char_error;
@@ -359,7 +359,7 @@ TokenReaderPtr tokenize_from_reader(CharReader &reader) {
             reader.skip();
             token_writer.push(Token(TOKEN_CHAR, p, str));
         } else if (is_dquote(c)) {
-            UnicodeString str = UnicodeString("");
+            icu::UnicodeString str = icu::UnicodeString("");
             str += c;
             reader.skip();
             if (reader.end() || is_eol(reader.look())) goto handle_string_error;
@@ -388,7 +388,7 @@ TokenReaderPtr tokenize_from_reader(CharReader &reader) {
              * or expanded with an exponent "[-]?[0-9]+[.][0-9]+[e][-]?[0-9]+".
              * A hexint is "0x[0-9a-f]+".
              */
-            UnicodeString str = UnicodeString("");
+            icu::UnicodeString str = icu::UnicodeString("");
             // handle leading '-'
             if (is_minus(c)) {
                 str += c;
@@ -457,7 +457,7 @@ TokenReaderPtr tokenize_from_reader(CharReader &reader) {
                 }
             }
         } else if (is_operator(c)) {
-            UnicodeString str = UnicodeString("");
+            icu::UnicodeString str = icu::UnicodeString("");
             while (is_operator(c)) {
                 str += c;
                 reader.skip();
@@ -465,7 +465,7 @@ TokenReaderPtr tokenize_from_reader(CharReader &reader) {
             };
             token_writer.push(adjust_reserved(Token(TOKEN_OPERATOR, p, str)));
         } else if (is_uppercase(c)) {
-            UnicodeString str = UnicodeString("");
+            icu::UnicodeString str = icu::UnicodeString("");
             while (is_letter(c)) {
                 str += c;
                 reader.skip();
@@ -473,7 +473,7 @@ TokenReaderPtr tokenize_from_reader(CharReader &reader) {
             };
             token_writer.push(adjust_reserved(Token(TOKEN_UPPERCASE, p, str)));
         } else if (is_lowercase(c)) {
-            UnicodeString str = UnicodeString("");
+            icu::UnicodeString str = icu::UnicodeString("");
             while (is_letter(c)) {
                 str += c;
                 reader.skip();
@@ -481,7 +481,7 @@ TokenReaderPtr tokenize_from_reader(CharReader &reader) {
             };
             token_writer.push(adjust_reserved(Token(TOKEN_LOWERCASE, p, str)));
         } else if (is_underscore(c)) { // XXX: push a lowercase for an underscore?
-            UnicodeString str = UnicodeString("");
+            icu::UnicodeString str = icu::UnicodeString("");
             str += c;
             reader.skip();
             token_writer.push(Token(TOKEN_LOWERCASE, p, str));
@@ -494,14 +494,14 @@ TokenReaderPtr tokenize_from_reader(CharReader &reader) {
 
     {
         Position p = reader.position();
-        token_writer.push(Token(TOKEN_EOF, p, UnicodeString("EOF")));
+        token_writer.push(Token(TOKEN_EOF, p, icu::UnicodeString("EOF")));
     }
 
     return token_writer.clone_reader();
 
     handle_error: {
         Position p = reader.position();
-        throw ErrorLexical(p, UnicodeString("unrecognized lexeme ") + reader.look());
+        throw ErrorLexical(p, icu::UnicodeString("unrecognized lexeme ") + reader.look());
     }
 
     handle_char_error: {

--- a/src/lexical.hpp
+++ b/src/lexical.hpp
@@ -74,11 +74,11 @@ typedef enum {
 
 } token_t;
 
-UnicodeString  token_text(token_t t);
+icu::UnicodeString  token_text(token_t t);
 
 class Token {
 public:
-    Token(token_t tag, const Position &position, const UnicodeString &text):
+    Token(token_t tag, const Position &position, const icu::UnicodeString &text):
         _tag(tag), _position(position), _text(text) {
     }
 
@@ -101,7 +101,7 @@ public:
         return _position;
     }
 
-    UnicodeString text() const {
+    icu::UnicodeString text() const {
         return _text;
     }
 
@@ -113,7 +113,7 @@ public:
 private:
     token_t         _tag;
     Position        _position;
-    UnicodeString   _text;
+    icu::UnicodeString   _text;
 };
 
 class TokenReader;
@@ -191,7 +191,7 @@ private:
     uint_t              _index;
 };
 
-UnicodeString  token_text(token_t t);
+icu::UnicodeString  token_text(token_t t);
 TokenReaderPtr tokenize_from_reader(CharReader &reader);
 
 #endif

--- a/src/lift.cpp
+++ b/src/lift.cpp
@@ -132,14 +132,14 @@ public:
         return _counter++;
     }
 
-    AstPtr combinator_expand(const AstPtr& c, UnicodeString s) {
+    AstPtr combinator_expand(const AstPtr& c, icu::UnicodeString s) {
         if (c->tag() == AST_EXPR_COMBINATOR) {
             AST_EXPR_COMBINATOR_SPLIT(c, p, nn, n);
-            UnicodeString n0 = n + "DOT" + s;
+            icu::UnicodeString n0 = n + "DOT" + s;
             return AstExprCombinator(p, nn, n0).clone();
         } else if (c->tag() == AST_EXPR_OPERATOR) {
             AST_EXPR_OPERATOR_SPLIT(c, p, nn, n); // XXX: keep source to source correct
-            UnicodeString n0 = n + "DOT" + s;
+            icu::UnicodeString n0 = n + "DOT" + s;
             return AstExprOperator(p, nn, n0).clone();
         } else {
             PANIC("combinator expected");

--- a/src/machine.hpp
+++ b/src/machine.hpp
@@ -14,8 +14,8 @@
 class SymbolTable {
 public:
     SymbolTable():
-            _to(std::vector<UnicodeString>()),
-            _from(std::map<UnicodeString, symbol_t>()) {
+            _to(std::vector<icu::UnicodeString>()),
+            _from(std::map<icu::UnicodeString, symbol_t>()) {
     }
 
     SymbolTable(const SymbolTable& other): 
@@ -41,7 +41,7 @@ public:
         ASSERT(_false == SYMBOL_FALSE);
     }
 
-    symbol_t enter(const UnicodeString& s) {
+    symbol_t enter(const icu::UnicodeString& s) {
         if (_from.count(s) == 0) {
             symbol_t n = _to.size();
             _to.push_back(s);
@@ -52,13 +52,13 @@ public:
         }
     }
 
-    symbol_t enter(const UnicodeString& n0, const UnicodeString& n1) {
-        UnicodeString n = n0 + STRING_COLON + n1;
+    symbol_t enter(const icu::UnicodeString& n0, const icu::UnicodeString& n1) {
+        icu::UnicodeString n = n0 + STRING_COLON + n1;
         return enter(n);
     }
 
-    symbol_t enter(const UnicodeStrings& nn, const UnicodeString& n) {
-        UnicodeString s;
+    symbol_t enter(const UnicodeStrings& nn, const icu::UnicodeString& n) {
+        icu::UnicodeString s;
         for (auto& n0: nn) {
             s += n0 + STRING_COLON;
         }
@@ -66,7 +66,7 @@ public:
         return enter(s);
     }
 
-    UnicodeString get(const symbol_t& s) {
+    icu::UnicodeString get(const symbol_t& s) {
         return _to[s];
     }
 
@@ -77,8 +77,8 @@ public:
     }
 
 private:
-    std::vector<UnicodeString>          _to;
-    std::map<UnicodeString, symbol_t>   _from;
+    std::vector<icu::UnicodeString>          _to;
+    std::map<icu::UnicodeString, symbol_t>   _from;
 };
 
 class DataTable {
@@ -168,27 +168,27 @@ public:
     }
 
     // import table manipulation
-    bool has_import(const UnicodeString& i) override {
+    bool has_import(const icu::UnicodeString& i) override {
         return false;
     }
 
-    void add_import(const UnicodeString& i) override {
+    void add_import(const icu::UnicodeString& i) override {
     }
 
     // symbol table manipulation
-    symbol_t enter_symbol(const UnicodeString& n) override {
+    symbol_t enter_symbol(const icu::UnicodeString& n) override {
         return _symbols.enter(n);
     }
 
-    symbol_t enter_symbol(const UnicodeString& n0, const UnicodeString& n1) override {
+    symbol_t enter_symbol(const icu::UnicodeString& n0, const icu::UnicodeString& n1) override {
         return _symbols.enter(n0, n1);
     }
 
-    symbol_t enter_symbol(const UnicodeStrings& nn, const UnicodeString& n) override {
+    symbol_t enter_symbol(const UnicodeStrings& nn, const icu::UnicodeString& n) override {
         return _symbols.enter(nn, n);
     }
 
-    UnicodeString get_symbol(symbol_t s) override {
+    icu::UnicodeString get_symbol(symbol_t s) override {
         return _symbols.get(s);
     }
 

--- a/src/modules.hpp
+++ b/src/modules.hpp
@@ -20,13 +20,13 @@
 #include "builtin/thread.hpp"
 
 // convenience
-inline UnicodeString first(const UnicodeString& s) {
+inline icu::UnicodeString first(const icu::UnicodeString& s) {
     auto d = s;
     auto i = d.indexOf(':');
     return d.remove(i, d.length());
 }
 
-inline UnicodeString second(const UnicodeString& s) {
+inline icu::UnicodeString second(const icu::UnicodeString& s) {
     auto d = s;
     auto i = d.indexOf(':');
     return d.remove(0, i+1);
@@ -83,11 +83,11 @@ public:
         return _library_path;
     }
 
-    void add_include_path(const UnicodeString& p) {
+    void add_include_path(const icu::UnicodeString& p) {
         _include_path.push_back(p);
     }
 
-    void add_library_path(const UnicodeString& p) {
+    void add_library_path(const icu::UnicodeString& p) {
         _library_path.push_back(p);
     }
 
@@ -197,7 +197,7 @@ public:
         _position(Position()), _filename("") {
     }
 
-    Import(const Position& p, const UnicodeString& fn):
+    Import(const Position& p, const icu::UnicodeString& fn):
         _position(p), _filename(fn) {
     }
 
@@ -209,12 +209,12 @@ public:
         return _position;
     }
 
-    UnicodeString filename() const {
+    icu::UnicodeString filename() const {
         return _filename;
     }
 private:
     Position        _position;
-    UnicodeString   _filename;
+    icu::UnicodeString   _filename;
 };
 
 typedef std::vector<Import>  Imports;
@@ -227,7 +227,7 @@ typedef enum {
 
 class Module {
 public:
-    Module(const module_tag_t t, const UnicodeString& p, const UnicodeString& fn, VM* m):
+    Module(const module_tag_t t, const icu::UnicodeString& p, const icu::UnicodeString& fn, VM* m):
         _tag(t), _path(p), _filename(fn), _machine(m) {
     }
 
@@ -241,11 +241,11 @@ public:
         return _options;
     }
 
-    UnicodeString get_path() const {
+    icu::UnicodeString get_path() const {
         return _path;
     }
 
-    UnicodeString get_filename() const {
+    icu::UnicodeString get_filename() const {
         return _filename;
     }
 
@@ -292,8 +292,8 @@ public:
 private:
     module_tag_t    _tag;
     OptionsPtr      _options;
-    UnicodeString   _path;
-    UnicodeString   _filename;
+    icu::UnicodeString   _path;
+    icu::UnicodeString   _filename;
     VM*             _machine;
 };
 
@@ -301,7 +301,7 @@ typedef std::vector<VMObjectPtr> (*exports_t)(VM*);
 
 class ModuleInternal: public Module {
 public:
-    ModuleInternal(const UnicodeString& fn, VM* m, const exports_t handle):
+    ModuleInternal(const icu::UnicodeString& fn, VM* m, const exports_t handle):
         Module(MODULE_INTERNAL, fn, fn, m),
             _handle(handle) {
     }
@@ -355,7 +355,7 @@ public:
         os << "dynamic module: " << get_filename();
     }
 
-    static bool filetype(const UnicodeString& fn) {
+    static bool filetype(const icu::UnicodeString& fn) {
         return unicode_endswith(fn, ".ego");
     }
 
@@ -372,7 +372,7 @@ private:
 
 class ModuleDynamic: public Module {
 public:
-    ModuleDynamic(const UnicodeString& p, const UnicodeString& fn, VM* m):
+    ModuleDynamic(const icu::UnicodeString& p, const icu::UnicodeString& fn, VM* m):
         Module(MODULE_DYNAMIC, p, fn, m),
             _handle(0), _imports(0), _exports(0) {
     }
@@ -394,17 +394,17 @@ public:
 
         _handle = dlopen(unicode_to_char(get_path()), RTLD_LAZY); // XXX: leaks?
         if (!_handle) {
-            UnicodeString err = "dynamic load error: ";
+            icu::UnicodeString err = "dynamic load error: ";
             err += dlerror();
             throw ErrorIO(err);
         }
 
-        std::vector<UnicodeString> (*egel_imports)();
-        egel_imports = (std::vector<UnicodeString> (*)())
+        std::vector<icu::UnicodeString> (*egel_imports)();
+        egel_imports = (std::vector<icu::UnicodeString> (*)())
                             dlsym(_handle, "egel_imports");
         error = dlerror();
         if (error != NULL) {
-            UnicodeString err = "dynamic load error: ";
+            icu::UnicodeString err = "dynamic load error: ";
             err += dlerror();
             throw ErrorIO(err);
         }
@@ -414,7 +414,7 @@ public:
                             dlsym(_handle, "egel_exports");
         error = dlerror();
         if (error != NULL) {
-            UnicodeString err = "dynamic load error: ";
+            icu::UnicodeString err = "dynamic load error: ";
             err += dlerror();
             throw ErrorIO(err);
         }
@@ -467,7 +467,7 @@ public:
         os << "dynamic module: " << get_filename();
     }
 
-    static bool filetype(const UnicodeString& fn) {
+    static bool filetype(const icu::UnicodeString& fn) {
         return unicode_endswith(fn, ".ego");
     }
 
@@ -480,7 +480,7 @@ private:
 
 class ModuleSource : public Module {
 public:
-    ModuleSource(const UnicodeString& path, const UnicodeString& fn, VM* m):
+    ModuleSource(const icu::UnicodeString& path, const icu::UnicodeString& fn, VM* m):
         Module(MODULE_SOURCE, path, fn, m),
         _source(""), _ast(0) {
     }
@@ -596,12 +596,12 @@ public:
         os << "source module " << get_filename();
     }
 
-    static bool filetype(const UnicodeString& fn) {
+    static bool filetype(const icu::UnicodeString& fn) {
         return unicode_endswith(fn, ".eg");
     }
 
 private:
-    UnicodeString   _source;
+    icu::UnicodeString   _source;
     AstPtr          _ast;
 };
 
@@ -664,7 +664,7 @@ public:
     }
 
     // implements incremental loading for interactive mode
-    void load(const Position& p, const UnicodeString& fn) {
+    void load(const Position& p, const icu::UnicodeString& fn) {
         preload(p, fn);
         _loading[0]->set_options(_options);
         transitive_closure();
@@ -681,17 +681,17 @@ public:
     }
 
 protected:
-    UnicodeString search(const UnicodeStrings& path, const UnicodeString& fn) {
+    icu::UnicodeString search(const UnicodeStrings& path, const icu::UnicodeString& fn) {
         // if (file_exists(fn)) return fn; // doesn't work with dynamic modules which should be given absolute paths
         for (auto p:path) {
-            UnicodeString fn0 = path_combine(p, fn);
+            icu::UnicodeString fn0 = path_combine(p, fn);
             if (file_exists(fn0)) return fn0;
         };
         return "";
     }
 
 
-    bool already_loaded(const UnicodeString& fn) {
+    bool already_loaded(const icu::UnicodeString& fn) {
         for (auto& m:_modules) {
             if (m->get_path().compare(fn) == 0) return true;
         }
@@ -701,7 +701,7 @@ protected:
         return false;
     }
 
-    void preload(const Position& p, const UnicodeString& fn) {
+    void preload(const Position& p, const icu::UnicodeString& fn) {
         if (fn[0] == '!') {
             // not implemented yet
         } else {

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -47,8 +47,8 @@ int     operator_char_entry(const UChar32& c) {
     return -1;
 }
 
-UnicodeString operator_char_translation(int i) {
-    return UnicodeString(operators[i].translation);
+icu::UnicodeString operator_char_translation(int i) {
+    return icu::UnicodeString(operators[i].translation);
 }
 
 attr_t operator_char_attributes(int i) {
@@ -79,7 +79,7 @@ int     operator_char_compare(const UChar32 c0, const UChar32 c1) {
 }
 
 
-int     operator_compare(const UnicodeString& o0, const UnicodeString& o1) {
+int     operator_compare(const icu::UnicodeString& o0, const icu::UnicodeString& o1) {
     int l0 = o0.length();
     int l1 = o1.length();
 
@@ -103,13 +103,13 @@ int     operator_compare(const UnicodeString& o0, const UnicodeString& o1) {
     return 0;
 }
 
-UChar32 operator_head_char(const UnicodeString& o) {
+UChar32 operator_head_char(const icu::UnicodeString& o) {
     ASSERT(o.length() > 0);
     UChar32 c = o.char32At(0);
     return c;
 }
 
-bool    operator_is_infix(const UnicodeString& o) {
+bool    operator_is_infix(const icu::UnicodeString& o) {
     UChar32 c = operator_head_char(o);
     int i = operator_char_entry(c);
     if (i < 0) {
@@ -120,7 +120,7 @@ bool    operator_is_infix(const UnicodeString& o) {
     }
 }
 
-bool    operator_is_prefix(const UnicodeString& o) {
+bool    operator_is_prefix(const icu::UnicodeString& o) {
     UChar32 c = operator_head_char(o);
     int i = operator_char_entry(c);
     if (i < 0) {
@@ -131,7 +131,7 @@ bool    operator_is_prefix(const UnicodeString& o) {
     }
 }
 
-bool    operator_is_postfix(const UnicodeString& o) {
+bool    operator_is_postfix(const icu::UnicodeString& o) {
     UChar32 c = operator_head_char(o);
     int i = operator_char_entry(c);
     if (i < 0) {
@@ -142,7 +142,7 @@ bool    operator_is_postfix(const UnicodeString& o) {
     }
 }
 
-bool    operator_is_left_associative(const UnicodeString& o) {
+bool    operator_is_left_associative(const icu::UnicodeString& o) {
     UChar32 c = operator_head_char(o);
     int i = operator_char_entry(c);
     if (i < 0) {
@@ -153,7 +153,7 @@ bool    operator_is_left_associative(const UnicodeString& o) {
     }
 }
 
-bool    operator_is_right_associative(const UnicodeString& o) {
+bool    operator_is_right_associative(const icu::UnicodeString& o) {
     UChar32 c = operator_head_char(o);
     int i = operator_char_entry(c);
     if (i < 0) {
@@ -164,7 +164,7 @@ bool    operator_is_right_associative(const UnicodeString& o) {
     }
 }
 
-bool    operator_is_not_associative(const UnicodeString& o) {
+bool    operator_is_not_associative(const icu::UnicodeString& o) {
     UChar32 c = operator_head_char(o);
     int i = operator_char_entry(c);
     if (i < 0) {
@@ -175,7 +175,7 @@ bool    operator_is_not_associative(const UnicodeString& o) {
     }
 }
 
-UnicodeString operator_to_ascii(const UnicodeString& o) {
+icu::UnicodeString operator_to_ascii(const icu::UnicodeString& o) {
     // XXX
     return "";
 }

--- a/src/operators.hpp
+++ b/src/operators.hpp
@@ -5,16 +5,16 @@
 
 #define OPERATOR_BOTTOM "="
 
-int     operator_compare(const UnicodeString& o0, const UnicodeString& o1);
+int     operator_compare(const icu::UnicodeString& o0, const icu::UnicodeString& o1);
 
-bool    operator_is_infix(const UnicodeString& o);
-bool    operator_is_prefix(const UnicodeString& o);
-bool    operator_is_postfix(const UnicodeString& o);
+bool    operator_is_infix(const icu::UnicodeString& o);
+bool    operator_is_prefix(const icu::UnicodeString& o);
+bool    operator_is_postfix(const icu::UnicodeString& o);
 
-bool    operator_is_left_associative(const UnicodeString& o);
-bool    operator_is_right_associative(const UnicodeString& o);
-bool    operator_is_not_associative(const UnicodeString& o);
+bool    operator_is_left_associative(const icu::UnicodeString& o);
+bool    operator_is_right_associative(const icu::UnicodeString& o);
+bool    operator_is_not_associative(const icu::UnicodeString& o);
 
-UnicodeString operator_to_ascii(const UnicodeString& o);
+icu::UnicodeString operator_to_ascii(const icu::UnicodeString& o);
 
 #endif

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -8,12 +8,12 @@
 class Position {
 public:
     Position() {
-        _resource = UnicodeString("");
+        _resource = icu::UnicodeString("");
         _row = 0;
         _column = 0;
     }
 
-    Position(const UnicodeString &resource, int32_t row, int32_t column) {
+    Position(const icu::UnicodeString &resource, int32_t row, int32_t column) {
         _resource = resource;
         _row = row;
         _column = column;
@@ -22,7 +22,7 @@ public:
     ~Position() {
     }
 
-    UnicodeString resource() const {
+    icu::UnicodeString resource() const {
         return _resource;
     }
 
@@ -34,10 +34,10 @@ public:
         return _column;
     }
 
-    UnicodeString to_text() {
+    icu::UnicodeString to_text() {
         std::stringstream ss;
         ss << *this;
-        UnicodeString u(ss.str().c_str());
+        icu::UnicodeString u(ss.str().c_str());
         return u;
     }
 
@@ -47,7 +47,7 @@ public:
     }
 
 private:
-    UnicodeString   _resource;
+    icu::UnicodeString   _resource;
     int32_t         _row;
     int32_t         _column;
 };

--- a/src/reader.hpp
+++ b/src/reader.hpp
@@ -19,7 +19,7 @@ public:
 
 class StringCharReader : public CharReader {
 public:
-    StringCharReader(const UnicodeString &resource, const UnicodeString &content) {
+    StringCharReader(const icu::UnicodeString &resource, const icu::UnicodeString &content) {
         _row = 1;
         _column = 1;
         _resource = resource;
@@ -31,7 +31,7 @@ public:
         return Position(_resource, _row, _column);
     }
 
-    UnicodeString content() {
+    icu::UnicodeString content() {
         return _content;
     }
 
@@ -79,11 +79,11 @@ public:
     }
 
 private:
-    UnicodeString _resource;
+    icu::UnicodeString _resource;
     int32_t _row;
     int32_t _column;
 
-    UnicodeString _content;
+    icu::UnicodeString _content;
     int32_t _index;
 };
 

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -29,8 +29,8 @@
 
 // libicu doesn't provide escaping..
 
-inline UnicodeString uescape(const UnicodeString& s) {
-    UnicodeString s1;
+inline icu::UnicodeString uescape(const icu::UnicodeString& s) {
+    icu::UnicodeString s1;
     int i=0;
     int len = s.length();
     for (i = 0; i < len; i++) {
@@ -95,7 +95,7 @@ typedef bool            vm_bool_t;
 typedef int64_t         vm_int_t;
 typedef double          vm_float_t;
 typedef UChar32         vm_char_t;
-typedef UnicodeString   vm_text_t;
+typedef icu::UnicodeString   vm_text_t;
 typedef void*           vm_ptr_t;
 
 // predefined symbols
@@ -153,10 +153,10 @@ public:
 
     virtual symbol_t symbol() const = 0;
 
-    UnicodeString to_text() {
+    icu::UnicodeString to_text() {
         std::stringstream ss;
         render(ss);
-        UnicodeString u(ss.str().c_str());
+        icu::UnicodeString u(ss.str().c_str());
         return u;
     }
 
@@ -179,14 +179,14 @@ public:
     VM() {};
 
     // import table manipulation
-    virtual bool has_import(const UnicodeString& i) = 0;
-    virtual void add_import(const UnicodeString& i) = 0;
+    virtual bool has_import(const icu::UnicodeString& i) = 0;
+    virtual void add_import(const icu::UnicodeString& i) = 0;
 
     // symbol table manipulation
-    virtual symbol_t enter_symbol(const UnicodeString& n) = 0;
-    virtual symbol_t enter_symbol(const UnicodeString& n0, const UnicodeString& n1) = 0;
-    virtual symbol_t enter_symbol(const std::vector<UnicodeString>& nn, const UnicodeString& n) = 0;
-    virtual UnicodeString get_symbol(symbol_t s) = 0;
+    virtual symbol_t enter_symbol(const icu::UnicodeString& n) = 0;
+    virtual symbol_t enter_symbol(const icu::UnicodeString& n0, const icu::UnicodeString& n1) = 0;
+    virtual symbol_t enter_symbol(const std::vector<icu::UnicodeString>& nn, const icu::UnicodeString& n) = 0;
+    virtual icu::UnicodeString get_symbol(symbol_t s) = 0;
 
     // data table manipulation
     virtual data_t enter_data(const VMObjectPtr& o) = 0;
@@ -205,9 +205,9 @@ public:
 
     // convenience routines
     VMObjectPtr get_data_symbol(const symbol_t t);
-    VMObjectPtr get_data_string(const UnicodeString& n);
-    VMObjectPtr get_data_string(const UnicodeString& n0, const UnicodeString& n1);
-    VMObjectPtr get_data_string(const std::vector<UnicodeString>& nn, const UnicodeString& n);
+    VMObjectPtr get_data_string(const icu::UnicodeString& n);
+    VMObjectPtr get_data_string(const icu::UnicodeString& n0, const icu::UnicodeString& n1);
+    VMObjectPtr get_data_string(const std::vector<icu::UnicodeString>& nn, const icu::UnicodeString& n);
 
 };
 
@@ -339,7 +339,7 @@ public:
     }
 
     void render(std::ostream& os) const override {
-        UnicodeString s;
+        icu::UnicodeString s;
         s = uescape(s+value());
         os << "'" << s << "'";
     }
@@ -363,13 +363,13 @@ typedef std::shared_ptr<VMObjectChar> VMObjectCharPtr;
 
 class VMObjectText : public VMObjectLiteral {
 public:
-    VMObjectText(const UnicodeString &v)
+    VMObjectText(const icu::UnicodeString &v)
         : VMObjectLiteral(VM_OBJECT_TEXT), _value(v) {
     };
 
     VMObjectText(const char* v)
         : VMObjectLiteral(VM_OBJECT_TEXT) {
-        _value = UnicodeString::fromUTF8(StringPiece(v));
+        _value = icu::UnicodeString::fromUTF8(icu::StringPiece(v));
     };
 
     VMObjectText(const VMObjectText& l)
@@ -380,7 +380,7 @@ public:
         return VMObjectPtr(new VMObjectText(*this));
     }
 
-    static VMObjectPtr create(const UnicodeString& v) {
+    static VMObjectPtr create(const icu::UnicodeString& v) {
         return VMObjectPtr(new VMObjectText(v));
     }
 
@@ -401,17 +401,17 @@ public:
     }
 
     void render(std::ostream& os) const override {
-        UnicodeString s;
+        icu::UnicodeString s;
         s = uescape(value());
         os << '"' << s << '"';
     }
 
-    UnicodeString value() const {
+    icu::UnicodeString value() const {
         return _value;
     }
 
 private:
-    UnicodeString    _value;
+    icu::UnicodeString    _value;
 };
 
 typedef std::shared_ptr<VMObjectText> VMObjectTextPtr;
@@ -629,15 +629,15 @@ public:
         : VMObject(VM_OBJECT_OPAQUE, VM_OBJECT_FLAG_INTERNAL), _machine(m), _symbol(s) {
     };
 
-    VMObjectOpaque(VM* m, const UnicodeString& n)
+    VMObjectOpaque(VM* m, const icu::UnicodeString& n)
         : VMObject(VM_OBJECT_OPAQUE, VM_OBJECT_FLAG_INTERNAL), _machine(m), _symbol(m->enter_symbol(n)) {
     };
 
-    VMObjectOpaque(VM* m, const UnicodeString& n0, const UnicodeString& n1)
+    VMObjectOpaque(VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1)
         : VMObject(VM_OBJECT_OPAQUE, VM_OBJECT_FLAG_INTERNAL), _machine(m), _symbol(m->enter_symbol(n0, n1)) {
     };
 
-    VMObjectOpaque(VM* m, const std::vector<UnicodeString>& nn, const UnicodeString& n)
+    VMObjectOpaque(VM* m, const std::vector<icu::UnicodeString>& nn, const icu::UnicodeString& n)
         : VMObject(VM_OBJECT_OPAQUE, VM_OBJECT_FLAG_INTERNAL), _machine(m), _symbol(m->enter_symbol(nn, n)) {
     };
 
@@ -649,7 +649,7 @@ public:
         return _symbol;
     }
 
-    UnicodeString text() const {
+    icu::UnicodeString text() const {
         return _machine->get_symbol(_symbol);
     }
 
@@ -710,15 +710,15 @@ public:
         : VMObject(VM_OBJECT_COMBINATOR, f), _machine(m), _symbol(s) {
     };
 
-    VMObjectCombinator(const vm_object_flag_t f, VM* m, const UnicodeString& n)
+    VMObjectCombinator(const vm_object_flag_t f, VM* m, const icu::UnicodeString& n)
         : VMObject(VM_OBJECT_COMBINATOR, f), _machine(m), _symbol(m->enter_symbol(n)) {
     };
 
-    VMObjectCombinator(const vm_object_flag_t f, VM* m, const UnicodeString& n0, const UnicodeString& n1)
+    VMObjectCombinator(const vm_object_flag_t f, VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1)
         : VMObject(VM_OBJECT_COMBINATOR, f), _machine(m), _symbol(m->enter_symbol(n0, n1)) {
     };
 
-    VMObjectCombinator(const vm_object_flag_t f, VM* m, const std::vector<UnicodeString>& nn, const UnicodeString& n)
+    VMObjectCombinator(const vm_object_flag_t f, VM* m, const std::vector<icu::UnicodeString>& nn, const icu::UnicodeString& n)
         : VMObject(VM_OBJECT_COMBINATOR, f), _machine(m), _symbol(m->enter_symbol(nn, n)) {
     };
 
@@ -730,7 +730,7 @@ public:
         return _symbol;
     }
 
-    UnicodeString text() const {
+    icu::UnicodeString text() const {
         return _machine->get_symbol(_symbol);
     }
 
@@ -796,15 +796,15 @@ public:
         : VMObjectCombinator(VM_OBJECT_FLAG_DATA, m, s) {
     };
 
-    VMObjectData(VM* m, const UnicodeString& n)
+    VMObjectData(VM* m, const icu::UnicodeString& n)
         : VMObjectCombinator(VM_OBJECT_FLAG_DATA, m, n) {
     };
 
-    VMObjectData(VM* m, const UnicodeString& n0, const UnicodeString& n1)
+    VMObjectData(VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1)
         : VMObjectCombinator(VM_OBJECT_FLAG_DATA, m, n0, n1) {
     };
 
-    VMObjectData(VM* m, const std::vector<UnicodeString>& nn, const UnicodeString& n)
+    VMObjectData(VM* m, const std::vector<icu::UnicodeString>& nn, const icu::UnicodeString& n)
         : VMObjectCombinator(VM_OBJECT_FLAG_DATA, m, nn, n) {
     };
 
@@ -986,17 +986,17 @@ inline VMObjectPtr VM::get_data_symbol(const symbol_t s) {
     return get_data(d);
 }
 
-inline VMObjectPtr VM::get_data_string(const UnicodeString& n) {
+inline VMObjectPtr VM::get_data_string(const icu::UnicodeString& n) {
     auto i = enter_symbol(n);
     return get_data_symbol(i);
 }
 
-inline VMObjectPtr VM::get_data_string(const UnicodeString& n0, const UnicodeString& n1) {
+inline VMObjectPtr VM::get_data_string(const icu::UnicodeString& n0, const icu::UnicodeString& n1) {
     auto i = enter_symbol(n0, n1);
     return get_data_symbol(i);
 }
 
-inline VMObjectPtr VM::get_data_string(const std::vector<UnicodeString>& nn, const UnicodeString& n) {
+inline VMObjectPtr VM::get_data_string(const std::vector<icu::UnicodeString>& nn, const icu::UnicodeString& n) {
     auto i = enter_symbol(nn, n);
     return get_data_symbol(i);
 }
@@ -1040,7 +1040,7 @@ public:
 
 class Opaque: public VMObjectOpaque {
 public:
-    Opaque(VM* m, const UnicodeString& n0, const UnicodeString& n1): 
+    Opaque(VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1): 
          VMObjectOpaque(m, n0, n1) {
     }
 
@@ -1059,7 +1059,7 @@ public:
 
 class Medadic: public VMObjectCombinator {
 public:
-    Medadic(VM* m, const UnicodeString& n0, const UnicodeString& n1): 
+    Medadic(VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1): 
          VMObjectCombinator(VM_OBJECT_FLAG_INTERNAL, m, n0, n1) {
     }
 
@@ -1139,7 +1139,7 @@ public:
 
 class Monadic: public VMObjectCombinator {
 public:
-    Monadic(VM* m, const UnicodeString& n0, const UnicodeString& n1): 
+    Monadic(VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1): 
          VMObjectCombinator(VM_OBJECT_FLAG_INTERNAL, m, n0, n1) {
     }
 
@@ -1221,7 +1221,7 @@ public:
 
 class Dyadic: public VMObjectCombinator {
 public:
-    Dyadic(VM* m, const UnicodeString& n0, const UnicodeString& n1): 
+    Dyadic(VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1): 
          VMObjectCombinator(VM_OBJECT_FLAG_INTERNAL, m, n0, n1) {
     }
 
@@ -1304,7 +1304,7 @@ public:
 
 class Triadic: public VMObjectCombinator {
 public:
-    Triadic(VM* m, const UnicodeString& n0, const UnicodeString& n1): 
+    Triadic(VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1): 
          VMObjectCombinator(VM_OBJECT_FLAG_INTERNAL, m, n0, n1) {
     }
 
@@ -1388,7 +1388,7 @@ public:
 
 class Variadic: public VMObjectCombinator {
 public:
-    Variadic(VM* m, const UnicodeString& n0, const UnicodeString& n1): 
+    Variadic(VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1): 
          VMObjectCombinator(VM_OBJECT_FLAG_INTERNAL, m, n0, n1) {
     }
 
@@ -1465,7 +1465,7 @@ public:
 
 class Binary: public VMObjectCombinator {
 public:
-    Binary(VM* m, const UnicodeString& n0, const UnicodeString& n1): 
+    Binary(VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1): 
          VMObjectCombinator(VM_OBJECT_FLAG_INTERNAL, m, n0, n1) {
     }
 
@@ -1551,7 +1551,7 @@ public:
 
 class Ternary: public VMObjectCombinator {
 public:
-    Ternary(VM* m, const UnicodeString& n0, const UnicodeString& n1): 
+    Ternary(VM* m, const icu::UnicodeString& n0, const icu::UnicodeString& n1): 
          VMObjectCombinator(VM_OBJECT_FLAG_INTERNAL, m, n0, n1) {
     }
 

--- a/src/semantical.cpp
+++ b/src/semantical.cpp
@@ -56,8 +56,8 @@ public:
     }
 
     // helper functions 
-    UnicodeString qualified(const UnicodeStrings& nn, const UnicodeString n) {
-        UnicodeString s;
+    icu::UnicodeString qualified(const UnicodeStrings& nn, const icu::UnicodeString n) {
+        icu::UnicodeString s;
         for (auto& n: nn) {
             s += n + STRING_COLON;
         }
@@ -66,7 +66,7 @@ public:
     }
 
     // visits
-    void visit_expr_combinator(const Position& p, const UnicodeStrings& nn, const UnicodeString& n) override {
+    void visit_expr_combinator(const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& n) override {
         switch (get_declare_state()) {
         case STATE_DECLARE_GLOBAL:
             try {
@@ -166,7 +166,7 @@ public:
     }
 
     // range manipulation
-    void declare(const Position& p, const UnicodeString& k, const UnicodeString& v) {
+    void declare(const Position& p, const icu::UnicodeString& k, const icu::UnicodeString& v) {
         try {
             ::declare(_range, k, v);
         } catch (ErrorSemantical &e) {
@@ -174,13 +174,13 @@ public:
         }
     }
 
-    bool has(const UnicodeString& k) {
-        UnicodeString tmp = ::get(_range, k);
+    bool has(const icu::UnicodeString& k) {
+        icu::UnicodeString tmp = ::get(_range, k);
         return (tmp != "");
     }
 
-    UnicodeString get(const Position& p, const UnicodeString& k) {
-        UnicodeString tmp = ::get(_range, k);
+    icu::UnicodeString get(const Position& p, const icu::UnicodeString& k) {
+        icu::UnicodeString tmp = ::get(_range, k);
         if (tmp == "") {
             throw ErrorSemantical(p, "undeclared " + k);
         } else {
@@ -188,8 +188,8 @@ public:
         }
     }
 
-    UnicodeString get(const Position& p, const UnicodeStrings& kk, const UnicodeString& k) {
-        UnicodeString tmp = ::get(_range, kk, k);
+    icu::UnicodeString get(const Position& p, const UnicodeStrings& kk, const icu::UnicodeString& k) {
+        icu::UnicodeString tmp = ::get(_range, kk, k);
         if (tmp == "") {
             throw ErrorSemantical(p, "undeclared " + k);
         } else {
@@ -228,7 +228,7 @@ public:
     }
 
     // rewrites
-    AstPtr rewrite_expr_variable(const Position& p, const UnicodeString& v) override {
+    AstPtr rewrite_expr_variable(const Position& p, const icu::UnicodeString& v) override {
         switch (get_identify_state()) {
         case STATE_IDENTIFY_USE: {
                 auto v1 = get(p, v);
@@ -247,7 +247,7 @@ public:
         }
     }
 
-    AstPtr rewrite_expr_combinator(const Position& p, const UnicodeStrings& nn, const UnicodeString& t) override {
+    AstPtr rewrite_expr_combinator(const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& t) override {
         UnicodeStrings ee;
         switch (get_identify_state()) {
         case STATE_IDENTIFY_PATTERN:
@@ -265,7 +265,7 @@ public:
         return nullptr; // play nice with -Wall
     }
 
-    AstPtr rewrite_expr_operator(const Position& p, const UnicodeStrings& nn, const UnicodeString& t) override {
+    AstPtr rewrite_expr_operator(const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& t) override {
         UnicodeStrings ee;
         switch (get_identify_state()) {
         case STATE_IDENTIFY_PATTERN: 

--- a/src/syntactical.cpp
+++ b/src/syntactical.cpp
@@ -8,7 +8,7 @@ public:
         return _imports;
     }
 
-    void visit_directive_import(const Position& p, const UnicodeString& i) override {
+    void visit_directive_import(const Position& p, const icu::UnicodeString& i) override {
         _imports.push_back(AstDirectImport(p, i).clone());
     }
 

--- a/src/syntactical.hpp
+++ b/src/syntactical.hpp
@@ -107,7 +107,7 @@ public:
         return look().tag() == TOKEN_UPPERCASE;
     }
 
-    UnicodeString peek_operator() {
+    icu::UnicodeString peek_operator() {
         // (uppercase '.')* operator
         uint_t i = 0;
         while ((look(i).tag() == TOKEN_UPPERCASE) && (look(i+1).tag() == TOKEN_COLON)) {
@@ -137,14 +137,14 @@ public:
     AstPtr parse_variable() {
         check_token(TOKEN_UPPERCASE);
         Position p = position();
-        UnicodeString s = look().text();
+        icu::UnicodeString s = look().text();
         skip();
         return AstExprVariable(p, s).clone();
     }
 
     AstPtr parse_wildcard() {
         Position p = position();
-        UnicodeString s = look().text();
+        icu::UnicodeString s = look().text();
         if (s != "_") throw ErrorSyntactical(p, "wildcard expected");
         skip();
         return AstExprWildcard(p, s).clone();
@@ -155,12 +155,12 @@ public:
         UnicodeStrings nn;
         while ( (tag(0) == TOKEN_UPPERCASE) &&
                 (tag(1) == TOKEN_COLON) ) {
-            UnicodeString n = look().text();
+            icu::UnicodeString n = look().text();
             skip(); skip();
             nn.push_back(n);
         };
         check_token(TOKEN_LOWERCASE);
-        UnicodeString n = look().text();
+        icu::UnicodeString n = look().text();
         skip();
         return AstExprCombinator(p, nn, n).clone();
     }
@@ -170,12 +170,12 @@ public:
         UnicodeStrings nn;
         while ( (tag(0) == TOKEN_UPPERCASE) &&
                 (tag(1) == TOKEN_COLON) ) {
-            UnicodeString n = look().text();
+            icu::UnicodeString n = look().text();
             skip(); skip();
             nn.push_back(n);
         };
         check_token(TOKEN_OPERATOR);
-        UnicodeString n = look().text();
+        icu::UnicodeString n = look().text();
         skip();
         return AstExprCombinator(p, nn, n).clone();
     }
@@ -185,12 +185,12 @@ public:
         UnicodeStrings nn;
         while ( (tag(0) == TOKEN_UPPERCASE) &&
                 (tag(1) == TOKEN_COLON) ) {
-            UnicodeString n = look().text();
+            icu::UnicodeString n = look().text();
             skip(); skip();
             nn.push_back(n);
         };
         check_token(TOKEN_OPERATOR);
-        UnicodeString n = '!' + look().text();
+        icu::UnicodeString n = '!' + look().text();
         skip();
         return AstExprCombinator(p, nn, n).clone();
     }
@@ -205,13 +205,13 @@ public:
     UnicodeStrings parse_namespace() {
         UnicodeStrings ss;
         check_token(TOKEN_UPPERCASE);
-        UnicodeString s = look().text();
+        icu::UnicodeString s = look().text();
         ss.push_back(s);
         skip();
         while ( (tag(0) == TOKEN_COLON) &&
                 (tag(1) == TOKEN_UPPERCASE) ) {
             skip();
-            UnicodeString s = look().text();
+            icu::UnicodeString s = look().text();
             skip();
             ss.push_back(s);
         };
@@ -563,7 +563,7 @@ public:
     }
 
     AstPtr parse_primary_prefix() {
-        UnicodeString s = peek_operator();
+        icu::UnicodeString s = peek_operator();
         if ((s != "") && operator_is_prefix(s)) {
             AstPtr o = parse_prefix_operator();
             AstPtr e = parse_primary_prefix();
@@ -609,12 +609,12 @@ public:
      *      return lhs
      */
 
-    AstPtr parse_arithmetic_expression_1(AstPtr e0, UnicodeString mp) {
+    AstPtr parse_arithmetic_expression_1(AstPtr e0, icu::UnicodeString mp) {
         AstPtr lhs = e0;
-        UnicodeString la = peek_operator();
+        icu::UnicodeString la = peek_operator();
         while (((la.compare("") != 0) && operator_is_infix(la)) && (operator_compare(la, mp) >= 0)) {
             Position p = position();
-            UnicodeString opt = la;
+            icu::UnicodeString opt = la;
             AstPtr op = parse_operator();
             AstPtr rhs = parse_primaries();
             la = peek_operator();
@@ -847,7 +847,7 @@ public:
         Position p = position();
         force_token(TOKEN_IMPORT);
         check_token(TOKEN_TEXT);
-        UnicodeString n = look().text();
+        icu::UnicodeString n = look().text();
         skip();
         return AstDirectImport(p, n).clone();
     }

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -109,7 +109,7 @@ public:
         _fv.erase(a);
     }
 
-    void visit_expr_variable(const Position& p, const UnicodeString& n) override {
+    void visit_expr_variable(const Position& p, const icu::UnicodeString& n) override {
         switch (get_state()) {
         case FREEVARS_INSERT:
             insert(AstExprVariable(p, n).clone());

--- a/src/transform.hpp
+++ b/src/transform.hpp
@@ -26,39 +26,39 @@ public:
     virtual void transform_pre(const AstPtr& a) {
     }
 
-    virtual AstPtr transform_expr_integer(const AstPtr& a, const Position& p, const UnicodeString& v) {
+    virtual AstPtr transform_expr_integer(const AstPtr& a, const Position& p, const icu::UnicodeString& v) {
         return a;
     }
 
-    virtual AstPtr transform_expr_hexinteger(const AstPtr& a, const Position& p, const UnicodeString& v) {
+    virtual AstPtr transform_expr_hexinteger(const AstPtr& a, const Position& p, const icu::UnicodeString& v) {
         return a;
     }
 
-    virtual AstPtr transform_expr_float(const AstPtr& a, const Position& p, const UnicodeString& v) {
+    virtual AstPtr transform_expr_float(const AstPtr& a, const Position& p, const icu::UnicodeString& v) {
         return a;
     }
 
-    virtual AstPtr transform_expr_character(const AstPtr& a, const Position& p, const UnicodeString& v) {
+    virtual AstPtr transform_expr_character(const AstPtr& a, const Position& p, const icu::UnicodeString& v) {
         return a;
     }
 
-    virtual AstPtr transform_expr_text(const AstPtr& a, const Position& p, const UnicodeString& v) {
+    virtual AstPtr transform_expr_text(const AstPtr& a, const Position& p, const icu::UnicodeString& v) {
         return a;
     }
 
-    virtual AstPtr transform_expr_variable(const AstPtr& a, const Position& p, const UnicodeString& n) {
+    virtual AstPtr transform_expr_variable(const AstPtr& a, const Position& p, const icu::UnicodeString& n) {
         return a;
     }
 
-    virtual AstPtr transform_expr_wildcard(const AstPtr& a, const Position& p, const UnicodeString& n) {
+    virtual AstPtr transform_expr_wildcard(const AstPtr& a, const Position& p, const icu::UnicodeString& n) {
         return a;
     }
 
-    virtual AstPtr transform_expr_combinator(const AstPtr& a, const Position& p, const UnicodeStrings& nn, const UnicodeString& n) {
+    virtual AstPtr transform_expr_combinator(const AstPtr& a, const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& n) {
         return a;
     }
 
-    virtual AstPtr transform_expr_operator(const AstPtr& a, const Position& p, const UnicodeStrings& nn, const UnicodeString& n) {
+    virtual AstPtr transform_expr_operator(const AstPtr& a, const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& n) {
         return a;
     }
 
@@ -131,7 +131,7 @@ public:
         return AstExprThrow(p, e0).clone();
     }
 
-    virtual AstPtr transform_directive_import(const AstPtr& a, const Position& p, const UnicodeString& i) {
+    virtual AstPtr transform_directive_import(const AstPtr& a, const Position& p, const icu::UnicodeString& i) {
         return a;
     }
 
@@ -368,40 +368,40 @@ public:
     }
 
     // literals
-    virtual AstPtr rewrite_expr_integer(const Position& p, const UnicodeString& v) {
+    virtual AstPtr rewrite_expr_integer(const Position& p, const icu::UnicodeString& v) {
         return AstExprInteger(p, v).clone();
     }
 
-    virtual AstPtr rewrite_expr_hexinteger(const Position& p, const UnicodeString& v) {
+    virtual AstPtr rewrite_expr_hexinteger(const Position& p, const icu::UnicodeString& v) {
         return AstExprHexInteger(p, v).clone();
     }
 
-    virtual AstPtr rewrite_expr_float(const Position& p, const UnicodeString& v) {
+    virtual AstPtr rewrite_expr_float(const Position& p, const icu::UnicodeString& v) {
         return AstExprFloat(p, v).clone();
     }
 
-    virtual AstPtr rewrite_expr_character(const Position& p, const UnicodeString& v) {
+    virtual AstPtr rewrite_expr_character(const Position& p, const icu::UnicodeString& v) {
         return AstExprCharacter(p, v).clone();
     }
 
-    virtual AstPtr rewrite_expr_text(const Position& p, const UnicodeString& v) {
+    virtual AstPtr rewrite_expr_text(const Position& p, const icu::UnicodeString& v) {
         return AstExprText(p, v).clone();
     }
 
     // variables and constants
-    virtual AstPtr rewrite_expr_variable(const Position& p, const UnicodeString& n) {
+    virtual AstPtr rewrite_expr_variable(const Position& p, const icu::UnicodeString& n) {
         return AstExprVariable(p, n).clone();
     }
 
-    virtual AstPtr rewrite_expr_wildcard(const Position& p, const UnicodeString& n) {
+    virtual AstPtr rewrite_expr_wildcard(const Position& p, const icu::UnicodeString& n) {
         return AstExprWildcard(p, n).clone();
     }
 
-    virtual AstPtr rewrite_expr_combinator(const Position& p, const UnicodeStrings& nn, const UnicodeString& n) {
+    virtual AstPtr rewrite_expr_combinator(const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& n) {
         return AstExprCombinator(p, nn, n).clone();
     }
 
-    virtual AstPtr rewrite_expr_operator(const Position& p, const UnicodeStrings& nn, const UnicodeString& n) {
+    virtual AstPtr rewrite_expr_operator(const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& n) {
         return AstExprOperator(p, nn, n).clone();
     }
 
@@ -476,7 +476,7 @@ public:
         return AstExprThrow(p, e0).clone();
     }
 
-    virtual AstPtr rewrite_directive_import(const Position& p, const UnicodeString& i) {
+    virtual AstPtr rewrite_directive_import(const Position& p, const icu::UnicodeString& i) {
         return AstDirectImport(p, i).clone();
     }
 
@@ -709,31 +709,31 @@ public:
         }
     }
 
-    virtual void visit_expr_integer(const Position& p, const UnicodeString& v) {
+    virtual void visit_expr_integer(const Position& p, const icu::UnicodeString& v) {
     }
 
-    virtual void visit_expr_hexinteger(const Position& p, const UnicodeString& v) {
+    virtual void visit_expr_hexinteger(const Position& p, const icu::UnicodeString& v) {
     }
 
-    virtual void visit_expr_float(const Position& p, const UnicodeString& v) {
+    virtual void visit_expr_float(const Position& p, const icu::UnicodeString& v) {
     }
 
-    virtual void visit_expr_character(const Position& p, const UnicodeString& v) {
+    virtual void visit_expr_character(const Position& p, const icu::UnicodeString& v) {
     }
 
-    virtual void visit_expr_text(const Position& p, const UnicodeString& v) {
+    virtual void visit_expr_text(const Position& p, const icu::UnicodeString& v) {
     }
 
-    virtual void visit_expr_variable(const Position& p, const UnicodeString& n) {
+    virtual void visit_expr_variable(const Position& p, const icu::UnicodeString& n) {
     }
 
-    virtual void visit_expr_wildcard(const Position& p, const UnicodeString& n) {
+    virtual void visit_expr_wildcard(const Position& p, const icu::UnicodeString& n) {
     }
 
-    virtual void visit_expr_combinator(const Position& p, const UnicodeStrings& nn, const UnicodeString& n) {
+    virtual void visit_expr_combinator(const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& n) {
     }
 
-    virtual void visit_expr_operator(const Position& p, const UnicodeStrings& nn, const UnicodeString& n) {
+    virtual void visit_expr_operator(const Position& p, const UnicodeStrings& nn, const icu::UnicodeString& n) {
     }
 
     virtual void visit_expr_tuple(const Position& p, const AstPtrs& tt) {
@@ -793,7 +793,7 @@ public:
         visit(e);
     }
 
-    virtual void visit_directive_import(const Position& p, const UnicodeString& i) {
+    virtual void visit_directive_import(const Position& p, const icu::UnicodeString& i) {
     }
 
     virtual void visit_directive_using(const Position& p, const UnicodeStrings& nn) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -55,14 +55,14 @@ bool exists_file(const char* filename) {
 
 // Unicode routines
 
-char* unicode_to_char(const UnicodeString &str) {
+char* unicode_to_char(const icu::UnicodeString &str) {
     auto len = str.extract(0, STRING_MAX_SIZE, nullptr, (uint32_t) 0);
     auto buffer = new char[len+1];
     str.extract(0, STRING_MAX_SIZE, buffer, len+1);
     return buffer;
 }
 
-UChar* unicode_to_uchar(const UnicodeString &str) {
+UChar* unicode_to_uchar(const icu::UnicodeString &str) {
     UErrorCode error = U_ZERO_ERROR;
     UChar* buffer = new UChar[str.length()+1];
     int32_t size = str.extract(buffer, sizeof(buffer), error);
@@ -74,28 +74,28 @@ UChar* unicode_to_uchar(const UnicodeString &str) {
     return buffer;
 }
 
-UnicodeString unicode_convert_uint(uint_t n) {
+icu::UnicodeString unicode_convert_uint(uint_t n) {
     std::stringstream ss;
     ss << n;
-    UnicodeString u(ss.str().c_str());
+    icu::UnicodeString u(ss.str().c_str());
     return u;
 }
 
-UnicodeString unicode_concat(const UnicodeString& s0, const UnicodeString& s1) {
-    UnicodeString s;
+icu::UnicodeString unicode_concat(const icu::UnicodeString& s0, const icu::UnicodeString& s1) {
+    icu::UnicodeString s;
     s += s0;
     s += s1;
     return s;
 }
 
-int64_t convert_to_int(const UnicodeString& s) {
+int64_t convert_to_int(const icu::UnicodeString& s) {
     char* buf = unicode_to_char(s);
     auto i = atol(buf);
     delete buf;
     return i;
 }
 
-int64_t convert_to_hexint(const UnicodeString& s) {
+int64_t convert_to_hexint(const icu::UnicodeString& s) {
     int i = 0;
     int64_t n = 0;
     UChar32 c = s.char32At(i);
@@ -114,59 +114,59 @@ int64_t convert_to_hexint(const UnicodeString& s) {
     return n;
 }
 
-double convert_to_float(const UnicodeString& s) {
+double convert_to_float(const icu::UnicodeString& s) {
     char* buf = unicode_to_char(s);
     auto f = atof(buf);
     delete buf;
     return f;
 }
 
-UChar32 convert_to_char(const UnicodeString& s) {
+UChar32 convert_to_char(const icu::UnicodeString& s) {
     auto s0 = unicode_strip_quotes(s);
     auto s1 = unicode_unescape(s0);
     return s1.char32At(0);
 }
 
-UnicodeString convert_to_text(const UnicodeString& s) {
+icu::UnicodeString convert_to_text(const icu::UnicodeString& s) {
     auto s0 = unicode_strip_quotes(s);
     auto s1 = unicode_unescape(s0);
     return s1;
 }
 
-UnicodeString convert_from_int(const int64_t& n) {
+icu::UnicodeString convert_from_int(const int64_t& n) {
     std::stringstream ss;
     ss << n;
-    UnicodeString u(ss.str().c_str());
+    icu::UnicodeString u(ss.str().c_str());
     return u;
 }
 
-UnicodeString convert_from_float(const double& f) {
+icu::UnicodeString convert_from_float(const double& f) {
     std::stringstream ss;
     ss << f;
-    UnicodeString u(ss.str().c_str());
+    icu::UnicodeString u(ss.str().c_str());
     return u;
 }
 
-UnicodeString convert_from_char(const UChar32& c) {
+icu::UnicodeString convert_from_char(const UChar32& c) {
     std::stringstream ss;
     ss << c;
-    UnicodeString u(ss.str().c_str());
+    icu::UnicodeString u(ss.str().c_str());
     auto u1 = unicode_escape(u);
     return u1;
 }
 
-UnicodeString convert_from_text(const UnicodeString& s) {
+icu::UnicodeString convert_from_text(const icu::UnicodeString& s) {
     auto s1 = unicode_escape(s);
     return s1;
 }
 
-UnicodeString unicode_strip_quotes(const UnicodeString& s) {
-    UnicodeString copy(s);
+icu::UnicodeString unicode_strip_quotes(const icu::UnicodeString& s) {
+    icu::UnicodeString copy(s);
     return copy.retainBetween(1, copy.length() -1);
 }
 
-UnicodeString unicode_escape(const UnicodeString& s) {
-    UnicodeString s1;
+icu::UnicodeString unicode_escape(const icu::UnicodeString& s) {
+    icu::UnicodeString s1;
     int i=0;
     int len = s.length();
     for (i = 0; i < len; i++) {
@@ -210,26 +210,26 @@ UnicodeString unicode_escape(const UnicodeString& s) {
     return s1;
 }
 
-UnicodeString unicode_unescape(const UnicodeString& s) {
+icu::UnicodeString unicode_unescape(const icu::UnicodeString& s) {
     return s.unescape();
 }
 
-bool unicode_endswith(const UnicodeString& s, const UnicodeString& suffix) {
+bool unicode_endswith(const icu::UnicodeString& s, const icu::UnicodeString& suffix) {
     return s.endsWith(suffix);
 }
 
 // basic I/O routines
 
-UnicodeString file_read(const UnicodeString &filename) {
+icu::UnicodeString file_read(const icu::UnicodeString &filename) {
     char* fn = unicode_to_char(filename);
     UChar* chars = read_utf8_file(fn);
     delete[] fn;
-    UnicodeString str = UnicodeString(chars);
+    icu::UnicodeString str = icu::UnicodeString(chars);
     delete[] chars;
     return str;
 }
 
-void file_write(const UnicodeString &filename, const UnicodeString &str) {
+void file_write(const icu::UnicodeString &filename, const icu::UnicodeString &str) {
     char* fn = unicode_to_char(filename);
     UChar* s  = unicode_to_uchar(str);
     write_utf8_file(fn, s);
@@ -237,16 +237,16 @@ void file_write(const UnicodeString &filename, const UnicodeString &str) {
     delete[] s;
 }
 
-bool file_exists(const UnicodeString &filename) {
+bool file_exists(const icu::UnicodeString &filename) {
     char* fn = unicode_to_char(filename);
     bool b = exists_file(fn);
     delete[] fn;
     return b;
 }
 
-UnicodeString path_combine(const UnicodeString& p0, const UnicodeString& p1) {
+icu::UnicodeString path_combine(const icu::UnicodeString& p0, const icu::UnicodeString& p1) {
     // XXX: OS specific so this should once be generalized.
-    if (p0.endsWith(UnicodeString("/"))) {
+    if (p0.endsWith(icu::UnicodeString("/"))) {
         return p0 + p1;
     } else {
         return p0 + '/' + p1;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -45,26 +45,26 @@ void panic_fail (const char *message, const char *file, uint_t line);
 #define DEBUG_ASSERT(_e)           ((void)0);
 #endif
 
-typedef std::vector<UnicodeString> UnicodeStrings;
+typedef std::vector<icu::UnicodeString> UnicodeStrings;
 // unicode routines
 
 /** 
- ** Converts a UnicodeString to a character array.
+ ** Converts a icu::UnicodeString to a character array.
  **
  ** @param str  the string
  **
  ** @return a character array (heap allocated)
  **/
-char* unicode_to_char(const UnicodeString &str);
+char* unicode_to_char(const icu::UnicodeString &str);
 
 /** 
- ** Converts a UnicodeString to a UChar array.
+ ** Converts a icu::UnicodeString to a UChar array.
  **
  ** @param str  the string
  **
  ** @return a UChar array (heap allocated)
  **/
-UChar* unicode_to_uchar(const UnicodeString &str);
+UChar* unicode_to_uchar(const icu::UnicodeString &str);
 
 /**
  ** Converts an unsigned int to Unicode.
@@ -73,7 +73,7 @@ UChar* unicode_to_uchar(const UnicodeString &str);
  **
  ** @return a Unicode string
  **/
-UnicodeString unicode_convert_uint(uint_t n);
+icu::UnicodeString unicode_convert_uint(uint_t n);
 
 /**
  ** Concatenate two unicode strings
@@ -83,7 +83,7 @@ UnicodeString unicode_convert_uint(uint_t n);
  **
  ** @return the concatenation, a Unicode string
  **/
-UnicodeString unicode_concat(const UnicodeString& s0, const UnicodeString& s1);
+icu::UnicodeString unicode_concat(const icu::UnicodeString& s0, const icu::UnicodeString& s1);
 
 /**
  ** Strip the leading and trailing quote of a Unicode string
@@ -92,7 +92,7 @@ UnicodeString unicode_concat(const UnicodeString& s0, const UnicodeString& s1);
  **
  ** @return a stripped string
  **/
-UnicodeString unicode_strip_quotes(const UnicodeString& s);
+icu::UnicodeString unicode_strip_quotes(const icu::UnicodeString& s);
 
 /**
  ** Escape certain characters in a Unicode string.
@@ -101,7 +101,7 @@ UnicodeString unicode_strip_quotes(const UnicodeString& s);
  **
  ** @return the escaped string
  **/
-UnicodeString unicode_escape(const UnicodeString& s);
+icu::UnicodeString unicode_escape(const icu::UnicodeString& s);
 
 /**
  ** Unescape certain characters in a Unicode string.
@@ -110,7 +110,7 @@ UnicodeString unicode_escape(const UnicodeString& s);
  **
  ** @return the unescaped string
  **/
-UnicodeString unicode_unescape(const UnicodeString& s);
+icu::UnicodeString unicode_unescape(const icu::UnicodeString& s);
 
 /**
  ** Determine if a string ends with a certain suffix.
@@ -120,7 +120,7 @@ UnicodeString unicode_unescape(const UnicodeString& s);
  **
  ** @return the unescaped string
  **/
-bool unicode_endswith(const UnicodeString& s, const UnicodeString& sf);
+bool unicode_endswith(const icu::UnicodeString& s, const icu::UnicodeString& sf);
 
 // convenience routines text to, and from, literals
 
@@ -131,7 +131,7 @@ bool unicode_endswith(const UnicodeString& s, const UnicodeString& sf);
  **
  ** @return the integer recognized
  **/
-int64_t convert_to_int(const UnicodeString& s);
+int64_t convert_to_int(const icu::UnicodeString& s);
 
 /**
  ** Parse and convert a hexadecimal integer. like 0xa3.
@@ -140,7 +140,7 @@ int64_t convert_to_int(const UnicodeString& s);
  **
  ** @return the integer recognized
  **/
-int64_t convert_to_hexint(const UnicodeString& s);
+int64_t convert_to_hexint(const icu::UnicodeString& s);
 
 /**
  ** Parse and convert a float. like 3.14.
@@ -149,7 +149,7 @@ int64_t convert_to_hexint(const UnicodeString& s);
  **
  ** @return the integer recognized
  **/
-double convert_to_float(const UnicodeString& s);
+double convert_to_float(const icu::UnicodeString& s);
 
 /**
  ** Parse and convert a char string. like 'a'.
@@ -158,7 +158,7 @@ double convert_to_float(const UnicodeString& s);
  **
  ** @return the char recognized
  **/
-UChar32 convert_to_char(const UnicodeString& s);
+UChar32 convert_to_char(const icu::UnicodeString& s);
 
 /**
  ** Parse and convert an integer. like 42.
@@ -167,7 +167,7 @@ UChar32 convert_to_char(const UnicodeString& s);
  **
  ** @return the integer recognized
  **/
-UnicodeString convert_from_int(const int64_t& s);
+icu::UnicodeString convert_from_int(const int64_t& s);
 
 /**
  ** Parse and convert a float. like 3.14.
@@ -176,7 +176,7 @@ UnicodeString convert_from_int(const int64_t& s);
  **
  ** @return the integer recognized
  **/
-UnicodeString convert_from_float(const double& s);
+icu::UnicodeString convert_from_float(const double& s);
 
 /**
  ** Parse and convert a char string. like 'a'.
@@ -185,7 +185,7 @@ UnicodeString convert_from_float(const double& s);
  **
  ** @return the char recognized
  **/
-UnicodeString convert_from_char(const UChar32& s);
+icu::UnicodeString convert_from_char(const UChar32& s);
 
 /**
  ** Parse and convert a text string. like "hello!".
@@ -194,7 +194,7 @@ UnicodeString convert_from_char(const UChar32& s);
  **
  ** @return the integer recognized
  **/
-UnicodeString convert_to_text(const UnicodeString& s);
+icu::UnicodeString convert_to_text(const icu::UnicodeString& s);
 
 // convenience io-routines
 
@@ -205,7 +205,7 @@ UnicodeString convert_to_text(const UnicodeString& s);
  **
  ** @return the contents of the file
  **/
-UnicodeString file_read(const UnicodeString &filename);
+icu::UnicodeString file_read(const icu::UnicodeString &filename);
 
 /** 
  ** Convenience. Writes a string to a file.
@@ -213,7 +213,7 @@ UnicodeString file_read(const UnicodeString &filename);
  ** @param filename     the filename
  ** @param str          the string
  **/
-void file_write(const UnicodeString &filename, const UnicodeString &str);
+void file_write(const icu::UnicodeString &filename, const icu::UnicodeString &str);
 
 /** 
  ** Convenience. Checks whether a given file exists. (Note the possible race conditions.)
@@ -222,7 +222,7 @@ void file_write(const UnicodeString &filename, const UnicodeString &str);
  **
  ** @return true iff the file exists
  **/
-bool file_exists(const UnicodeString &filename);
+bool file_exists(const icu::UnicodeString &filename);
 
 /** 
  ** Convenience. Combine two paths into a new path. OS specific.
@@ -232,6 +232,6 @@ bool file_exists(const UnicodeString &filename);
  **
  ** @return the combined path
  **/
-UnicodeString path_combine(const UnicodeString& p0, const UnicodeString& p1);
+icu::UnicodeString path_combine(const icu::UnicodeString& p0, const icu::UnicodeString& p1);
 
 #endif


### PR DESCRIPTION
Since ICU 61, the several references to `UnicodeString`, `StringPiece`, `RegexPattern`, and `RegexMatcher` have to be replaced with `icu::UnicodeString`, `icu::StringPiece`, `icu::RegexPattern`, and `icu::RegexMatcher`.

The modified code works with old and new ICU versions alike. I've tested it on Fedora 28 (ICU 60) and Fedora 29 (ICU 62).