### PR TITLE
Fix typo in System::- subtraction

### DIFF
--- a/src/builtin_system.hpp
+++ b/src/builtin_system.hpp
@@ -145,7 +145,7 @@ public:
     }
 };
 
-//## System::+ x y - substraction
+//## System::- x y - subtraction
 class Min : public Dyadic {
 public:
     DYADIC_PREAMBLE(VM_SUB_BUILTIN, Min, "System", "-");


### PR DESCRIPTION
I noticed the typo here: https://github.com/egel-lang/egel-gen/blob/main/combs.md

I'm not sure if that is generated from this source or whether another PR is needed to correct those docs too?